### PR TITLE
return instance_dice of 0.0 instead of NaN when missing predictions

### DIFF
--- a/panoptica/result.py
+++ b/panoptica/result.py
@@ -172,7 +172,7 @@ class PanopticaResult:
             float: Average Dice coefficient.
         """
         if self.tp == 0: return 0.0
-        else: return np.sum(self._dice_list) / (self.tp + self.fn)
+        else: return np.sum(self._dice_list) / self.tp
 
     @property
     def instance_dice_sd(self) -> float:

--- a/panoptica/result.py
+++ b/panoptica/result.py
@@ -171,8 +171,9 @@ class PanopticaResult:
         Returns:
             float: Average Dice coefficient.
         """
-        if self.tp == 0: return 0.0
-        else: return np.sum(self._dice_list) / self.tp
+        if self.tp == 0: 
+            return 0.0
+        return np.sum(self._dice_list) / self.tp
 
     @property
     def instance_dice_sd(self) -> float:

--- a/panoptica/result.py
+++ b/panoptica/result.py
@@ -172,7 +172,7 @@ class PanopticaResult:
             float: Average Dice coefficient.
         """
         if self.tp == 0: return 0.0
-        else: return np.sum(self._dice_list) / self.tp
+        else: return np.sum(self._dice_list) / (self.tp + self.fn)
 
     @property
     def instance_dice_sd(self) -> float:

--- a/panoptica/result.py
+++ b/panoptica/result.py
@@ -171,7 +171,8 @@ class PanopticaResult:
         Returns:
             float: Average Dice coefficient.
         """
-        return np.sum(self._dice_list) / self.tp
+        if self.tp == 0: return 0.0
+        else: return np.sum(self._dice_list) / self.tp
 
     @property
     def instance_dice_sd(self) -> float:


### PR DESCRIPTION
Handles edge case of 0 true positives: return instance_dice = 0.0 instead of NaN.