### PR TITLE
Hendrik clean

### DIFF
--- a/examples/example_spine_semantic.py
+++ b/examples/example_spine_semantic.py
@@ -1,9 +1,18 @@
 from auxiliary.nifti.io import read_nifti
+import cProfile
 
-from panoptica import SemanticPair, Panoptic_Evaluator, ConnectedComponentsInstanceApproximator, CCABackend, NaiveOneToOneMatching
 
-ref_masks = read_nifti("examples/spine_seg/semantic_example/sub-0007_mod-T2w_seg-spine_msk.nii.gz")
-pred_masks = read_nifti("examples/spine_seg/semantic_example/sub-0007_mod-T2w_seg-spine_msk_new.nii.gz")
+from panoptica import (
+    SemanticPair,
+    MatchedInstancePair,
+    Panoptic_Evaluator,
+    ConnectedComponentsInstanceApproximator,
+    CCABackend,
+    NaiveOneToOneMatching,
+)
+
+ref_masks = read_nifti("repo/examples/spine_seg/semantic_example/sub-0007_mod-T2w_seg-spine_msk.nii.gz")
+pred_masks = read_nifti("repo/examples/spine_seg/semantic_example/sub-0007_mod-T2w_seg-spine_msk_new.nii.gz")
 
 
 sample = SemanticPair(pred_masks, ref_masks)
@@ -15,5 +24,10 @@ evaluator = Panoptic_Evaluator(
     iou_threshold=0.5,
 )
 
-result, debug_data = evaluator.evaluate(sample)
-print(result)
+from BIDS.logger.log_file import get_time, format_time_short
+
+timestamp = format_time_short(get_time())
+with cProfile.Profile() as pr:
+    result, debug_data = evaluator.evaluate(sample)
+    print(result)
+pr.dump_stats(f"repo/examples/cprofile_{timestamp}_log.log")

--- a/panoptica/_functionals.py
+++ b/panoptica/_functionals.py
@@ -1,10 +1,10 @@
 import numpy as np
-from multiprocessing import Pool
 from panoptica.utils.metrics import _compute_instance_iou
 from panoptica.utils.constants import CCABackend
+from joblib import Parallel, delayed
 
 
-def _calc_iou_matrix(prediction_arr: np.ndarray, reference_arr: np.ndarray, ref_labels: list[int], pred_labels: list[int]):
+def _calc_iou_matrix(prediction_arr: np.ndarray, reference_arr: np.ndarray, ref_labels: tuple[int, ...], pred_labels: tuple[int, ...]):
     """
     Calculate the Intersection over Union (IoU) matrix between reference and prediction arrays.
 
@@ -26,13 +26,13 @@ def _calc_iou_matrix(prediction_arr: np.ndarray, reference_arr: np.ndarray, ref_
     num_ref_instances = len(ref_labels)
     num_pred_instances = len(pred_labels)
 
-    # Create a pool of worker processes to parallelize the computation
-    with Pool() as pool:
-        # Generate all possible pairs of instance indices for IoU computation
-        instance_pairs = [(reference_arr, prediction_arr, ref_idx, pred_idx) for ref_idx in ref_labels for pred_idx in pred_labels]
-
-        # Calculate IoU for all instance pairs in parallel using starmap
-        iou_values = pool.starmap(_compute_instance_iou, instance_pairs)
+    iou_values = Parallel(n_jobs=4, backend="threading")(
+        delayed(_compute_instance_iou)(
+            reference_arr=reference_arr, prediction_arr=prediction_arr, ref_instance_idx=ref_idx, pred_instance_idx=pred_idx
+        )
+        for ref_idx in ref_labels
+        for pred_idx in pred_labels
+    )
 
     # Reshape the resulting IoU values into a matrix
     iou_matrix = np.array(iou_values).reshape((num_ref_instances, num_pred_instances))
@@ -49,11 +49,12 @@ def _map_labels(arr: np.ndarray, label_map: dict[np.integer, np.integer]) -> np.
     Returns:
         np.ndarray: Returns a copy of the remapped array
     """
-    data = arr.copy()
-    for v in np.unique(data):
-        if v in label_map:  # int needed to match non-integer data-types
-            data[arr == v] = label_map[v]
-    return data
+    k = np.array(list(label_map.keys()))
+    v = np.array(list(label_map.values()))
+
+    mapping_ar = np.arange(arr.max() + 1, dtype=arr.dtype)
+    mapping_ar[k] = v
+    return mapping_ar[arr]
 
 
 def _connected_components(

--- a/panoptica/evaluator.py
+++ b/panoptica/evaluator.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Type
 
 import numpy as np
 
@@ -13,7 +14,7 @@ from panoptica.timing import measure_time
 class Panoptic_Evaluator:
     def __init__(
         self,
-        expected_input: type(SemanticPair) | type(UnmatchedInstancePair) | type(MatchedInstancePair) = type(MatchedInstancePair),
+        expected_input: Type[SemanticPair] | Type[UnmatchedInstancePair] | Type[MatchedInstancePair] = MatchedInstancePair,
         instance_approximator: InstanceApproximator | None = None,
         instance_matcher: InstanceMatchingAlgorithm | None = None,
         iou_threshold: float = 0.5,
@@ -83,6 +84,8 @@ def panoptic_evaluate(
 
     if isinstance(processing_pair, SemanticPair):
         assert instance_approximator is not None, "Got SemanticPair but not InstanceApproximator"
+
+        print("Approximate Instances")
         processing_pair = instance_approximator.approximate_instances(processing_pair)
         debug_data["UnmatchedInstanceMap"] = processing_pair.copy()
 
@@ -92,7 +95,10 @@ def panoptic_evaluate(
 
     if isinstance(processing_pair, UnmatchedInstancePair):
         assert instance_matcher is not None, "Got UnmatchedInstancePair but not InstanceMatchingAlgorithm"
+
+        print("Match Instances")
         processing_pair = instance_matcher.match_instances(processing_pair)
+
         debug_data["MatchedInstanceMap"] = processing_pair.copy()
 
     # Third Phase: Instance Evaluation
@@ -100,6 +106,7 @@ def panoptic_evaluate(
         processing_pair = _handle_zero_instances_cases(processing_pair)
 
     if isinstance(processing_pair, MatchedInstancePair):
+        print("Evaluate Matched Instances")
         processing_pair = evaluate_matched_instance(processing_pair, iou_threshold=iou_threshold)
 
     if isinstance(processing_pair, PanopticaResult):

--- a/panoptica/instance_evaluator.py
+++ b/panoptica/instance_evaluator.py
@@ -5,7 +5,7 @@ import numpy as np
 from panoptica.utils.metrics import _compute_iou, _compute_dice_coefficient
 
 
-def evaluate_matched_instance(semantic_pair: MatchedInstancePair, iou_threshold: float, **kwargs) -> PanopticaResult:
+def evaluate_matched_instance(matched_instance_pair: MatchedInstancePair, iou_threshold: float, **kwargs) -> PanopticaResult:
     """
     Map instance labels based on the provided labelmap and create a MatchedInstancePair.
 
@@ -24,8 +24,8 @@ def evaluate_matched_instance(semantic_pair: MatchedInstancePair, iou_threshold:
     # Initialize variables for True Positives (tp)
     tp, dice_list, iou_list = 0, [], []
 
-    reference_arr, prediction_arr = semantic_pair.reference_arr, semantic_pair.prediction_arr
-    ref_labels = semantic_pair.ref_labels
+    reference_arr, prediction_arr = matched_instance_pair.reference_arr, matched_instance_pair.prediction_arr
+    ref_labels = matched_instance_pair.ref_labels
 
     # Use concurrent.futures.ThreadPoolExecutor for parallelization
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -43,13 +43,13 @@ def evaluate_matched_instance(semantic_pair: MatchedInstancePair, iou_threshold:
         for future in concurrent.futures.as_completed(futures):
             tp_i, dice_i, iou_i = future.result()
             tp += tp_i
-            if dice_i is not None and iou_i is not None:
+            if dice_i is not None or iou_i is not None:
                 dice_list.append(dice_i)
                 iou_list.append(iou_i)
     # Create and return the PanopticaResult object with computed metrics
     return PanopticaResult(
-        num_ref_instances=semantic_pair.n_reference_instance,
-        num_pred_instances=semantic_pair.n_prediction_instance,
+        num_ref_instances=matched_instance_pair.n_reference_instance,
+        num_pred_instances=matched_instance_pair.n_prediction_instance,
         tp=tp,
         dice_list=dice_list,
         iou_list=iou_list,

--- a/panoptica/instance_matcher.py
+++ b/panoptica/instance_matcher.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABC
-from panoptica.utils.datatypes import UnmatchedInstancePair, MatchedInstancePair, Instance_Label_Map
+from panoptica.utils.datatypes import UnmatchedInstancePair, MatchedInstancePair, InstanceLabelMap
 import numpy as np
 from panoptica._functionals import _map_labels, _calc_iou_matrix
 from scipy.optimize import linear_sum_assignment
@@ -31,7 +31,7 @@ class InstanceMatchingAlgorithm(ABC):
     """
 
     @abstractmethod
-    def _match_instances(self, unmatched_instance_pair: UnmatchedInstancePair, **kwargs) -> Instance_Label_Map:
+    def _match_instances(self, unmatched_instance_pair: UnmatchedInstancePair, **kwargs) -> InstanceLabelMap:
         """
         Abstract method to be implemented by subclasses for instance matching.
 
@@ -56,8 +56,8 @@ class InstanceMatchingAlgorithm(ABC):
             MatchedInstancePair: The result of the instance matching.
         """
         instance_labelmap = self._match_instances(unmatched_instance_pair, **kwargs)
-        print("instance_labelmap", instance_labelmap)
-        return map_instance_labels(unmatched_instance_pair.copy(), instance_labelmap)
+        # print("instance_labelmap", instance_labelmap)
+        return _map_instance_labels(unmatched_instance_pair.copy(), instance_labelmap)
 
 
 class NaiveOneToOneMatching(InstanceMatchingAlgorithm):
@@ -96,7 +96,7 @@ class NaiveOneToOneMatching(InstanceMatchingAlgorithm):
         assert iou_threshold < 1.0, "NaiveOneToOneMatching: iou_threshold greater than or equal to 1.0 doesnt work!"
         self.iou_threshold = iou_threshold
 
-    def _match_instances(self, unmatched_instance_pair: UnmatchedInstancePair, **kwargs) -> Instance_Label_Map:
+    def _match_instances(self, unmatched_instance_pair: UnmatchedInstancePair, **kwargs) -> InstanceLabelMap:
         """
         Perform one-to-one instance matching based on IoU values.
 
@@ -110,29 +110,30 @@ class NaiveOneToOneMatching(InstanceMatchingAlgorithm):
         ref_labels = unmatched_instance_pair.ref_labels
         pred_labels = unmatched_instance_pair.pred_labels
         iou_matrix = _calc_iou_matrix(
-            unmatched_instance_pair.prediction_arr,
-            unmatched_instance_pair.reference_arr,
+            unmatched_instance_pair.prediction_arr.flatten(),
+            unmatched_instance_pair.reference_arr.flatten(),
             ref_labels,
             pred_labels,
         )
         # Use linear_sum_assignment to find the best matches
-        ref_indices, pred_indices = linear_sum_assignment(-iou_matrix)
+        # ref_indices, pred_indices = linear_sum_assignment(-iou_matrix)
 
         # Initialize variables for True Positives (tp) and False Positives (fp)
-        labelmap: Instance_Label_Map = []
+        labelmap = InstanceLabelMap()
+
+        pairs = [(r, p) for r in range(len(ref_labels)) for p in range(len(pred_labels))]
 
         # Loop through matched instances to compute PQ components
-        for ref_idx, pred_idx in zip(ref_indices, pred_indices):
-            # TODO skip indices that have been matched already
+        for ref_idx, pred_idx in pairs:
             iou = iou_matrix[ref_idx][pred_idx]
             if iou >= self.iou_threshold:
                 # Match found, increment true positive count and collect IoU and Dice values
-                labelmap.append(([ref_labels[ref_idx]], [pred_labels[pred_idx]]))
+                labelmap.add_labelmap_entry(pred_labels[pred_idx], ref_labels[ref_idx])
                 # map label ref_idx to pred_idx
         return labelmap
 
 
-def map_instance_labels(processing_pair: UnmatchedInstancePair, labelmap: Instance_Label_Map) -> MatchedInstancePair:
+def _map_instance_labels(processing_pair: UnmatchedInstancePair, labelmap: InstanceLabelMap) -> MatchedInstancePair:
     """
     Map instance labels based on the provided labelmap and create a MatchedInstancePair.
 
@@ -148,47 +149,35 @@ def map_instance_labels(processing_pair: UnmatchedInstancePair, labelmap: Instan
     >>> labelmap = [([1, 2], [3, 4]), ([5], [6])]
     >>> result = map_instance_labels(unmatched_instance_pair, labelmap)
     """
-    prediction_arr, reference_arr = processing_pair.prediction_arr, processing_pair.reference_arr
+    prediction_arr = processing_pair.prediction_arr
 
     ref_labels = processing_pair.ref_labels
     pred_labels = processing_pair.pred_labels
 
-    missed_ref_labels = []
-    missed_pred_labels = []
+    ref_matched_labels = []
+    label_counter = max(ref_labels) + 1
 
-    pred_labelmap = {}
-    ref_labelmap = {}
-    label_counter = 1
-    # TODO map only predictions onto reference, but vice versa (leave reference untouched, unmatched predictions get next best labels)
-    # -> that would mean only many-to-one matching allowed
+    pred_labelmap = labelmap.get_one_to_one_dictionary()
+    ref_matched_labels = list([r for r in ref_labels if r in pred_labelmap.values()])
 
-    # Go over instance labelmap and assign the matched instance sequentially
-    for refs, preds in labelmap:
-        for r, p in zip(refs, preds):
-            ref_labelmap[r] = label_counter
-            pred_labelmap[p] = label_counter
-        label_counter += 1
-    n_matched_instances = label_counter - 1
+    n_matched_instances = len(ref_matched_labels)
+
     # assign missed instances to next unused labels sequentially
-    for r in ref_labels:
-        if r not in ref_labelmap:
-            ref_labelmap[r] = label_counter
-            label_counter += 1
-            missed_ref_labels.append(r)
-    for p in pred_labels:
-        if p not in pred_labelmap:
-            pred_labelmap[p] = label_counter
-            label_counter += 1
-            missed_ref_labels.append(p)
+    missed_ref_labels = list([r for r in ref_labels if r not in ref_matched_labels])
+    missed_pred_labels = list([p for p in pred_labels if p not in pred_labelmap])
+    for p in missed_pred_labels:
+        pred_labelmap[p] = label_counter
+        label_counter += 1
+
+    assert np.all([i in pred_labelmap for i in pred_labels])
 
     # Using the labelmap, actually change the labels in the array here
-    prediction_arr_relabeled = _map_labels(prediction_arr, pred_labelmap)
-    reference_arr_relabeled = _map_labels(reference_arr, ref_labelmap)
+    prediction_arr_relabeled = _map_labels(prediction_arr, pred_labelmap)  # type:ignore
 
     # Build a MatchedInstancePair out of the newly derived data
     matched_instance_pair = MatchedInstancePair(
         prediction_arr=prediction_arr_relabeled,
-        reference_arr=reference_arr_relabeled,
+        reference_arr=processing_pair.reference_arr,
         missed_reference_labels=missed_ref_labels,
         missed_prediction_labels=missed_pred_labels,
         n_prediction_instance=processing_pair.n_prediction_instance,
@@ -196,17 +185,3 @@ def map_instance_labels(processing_pair: UnmatchedInstancePair, labelmap: Instan
         n_matched_instances=n_matched_instances,
     )
     return matched_instance_pair
-
-
-if __name__ == "__main__":
-    a = np.array([0, 1, 2, 3, 4, 5], dtype=np.uint16)
-    b = np.array([0, 1, 2, 6, 3, 7], dtype=np.uint16)
-    MatchedInstancePair(
-        reference_arr=a,
-        prediction_arr=b,
-        missed_reference_labels=[4, 5],
-        missed_prediction_labels=[6, 7],
-        n_matched_instances=3,
-        n_prediction_instance=5,
-        n_reference_instance=5,
-    )

--- a/panoptica/utils/__init__.py
+++ b/panoptica/utils/__init__.py
@@ -1,5 +1,5 @@
 from panoptica.utils.numpy_utils import _count_unique_without_zeros, _unique_without_zeros
-from panoptica.utils.datatypes import SemanticPair, UnmatchedInstancePair, MatchedInstancePair, Instance_Label_Map
+from panoptica.utils.datatypes import SemanticPair, UnmatchedInstancePair, MatchedInstancePair, InstanceLabelMap
 from panoptica.utils.metrics import _compute_instance_volumetric_dice, _compute_instance_iou, _compute_dice_coefficient, _compute_iou
 
 # from utils.constants import

--- a/panoptica/utils/datatypes.py
+++ b/panoptica/utils/datatypes.py
@@ -254,9 +254,6 @@ class InstanceLabelMap:
         self.__dict__[attr] = value
 
 
-Instance_Label_Map = list[tuple[list[int], int]]
-
-
 if __name__ == "__main__":
     n = np.zeros([50, 50], dtype=np.int32)
     a = SemanticPair(n, n)

--- a/panoptica/utils/datatypes.py
+++ b/panoptica/utils/datatypes.py
@@ -199,8 +199,49 @@ class MatchedInstancePair(_ProcessingPairInstanced):
         )
 
 
-# Mapping ((prediction_label, ...), (reference_label, ...))
-Instance_Label_Map = list[tuple[list[uint_type], list[uint_type]]]
+# Many-to-One Mapping
+class InstanceLabelMap:
+    # Mapping ((prediction_label, ...), (reference_label, ...))
+    labelmap: dict[int, int]
+
+    def __init__(self) -> None:
+        self.labelmap = {}
+
+    def add_labelmap_entry(self, pred_labels: list[int] | int, ref_label: int):
+        if not isinstance(pred_labels, list):
+            pred_labels = [pred_labels]
+        for p in pred_labels:
+            if p in self.labelmap and self.labelmap[p] != ref_label:
+                raise Exception(
+                    f"You are mapping a prediction label to a reference label that was already assigned differently, got {self.__str__} and you tried {pred_labels}, {ref_label}"
+                )
+            self.labelmap[p] = ref_label
+
+    def get_one_to_one_dictionary(self):
+        return self.labelmap
+
+    def __str__(self) -> str:
+        return str(
+            list(
+                [
+                    str(tuple(k for k in self.labelmap.keys() if self.labelmap[k] == v)) + " -> " + str(v)
+                    for v in set(self.labelmap.values())
+                ]
+            )
+        )
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    # Make all variables read-only!
+    def __setattr__(self, attr, value):
+        if hasattr(self, attr):
+            raise Exception("Attempting to alter read-only value")
+
+        self.__dict__[attr] = value
+
+
+Instance_Label_Map = list[tuple[list[int], int]]
 
 
 if __name__ == "__main__":
@@ -208,3 +249,7 @@ if __name__ == "__main__":
     a = SemanticPair(n, n)
     print(a)
     # print(a.prediction_arr)
+
+    map = InstanceLabelMap()
+    map.labelmap = {2: 3, 3: 3, 4: 6}
+    print(map)

--- a/panoptica/utils/metrics.py
+++ b/panoptica/utils/metrics.py
@@ -38,8 +38,8 @@ def _compute_instance_volumetric_dice(
 
 
 def _compute_instance_iou(
-    ref_labels: np.ndarray,
-    pred_labels: np.ndarray,
+    reference_arr: np.ndarray,
+    prediction_arr: np.ndarray,
     ref_instance_idx: int,
     pred_instance_idx: int,
 ) -> float:
@@ -55,8 +55,8 @@ def _compute_instance_iou(
     Returns:
         float: IoU between the specified instances.
     """
-    ref_instance_mask = ref_labels == ref_instance_idx
-    pred_instance_mask = pred_labels == pred_instance_idx
+    ref_instance_mask = reference_arr == ref_instance_idx
+    pred_instance_mask = prediction_arr == pred_instance_idx
     intersection = np.logical_and(ref_instance_mask, pred_instance_mask)
     union = np.logical_or(ref_instance_mask, pred_instance_mask)
 


### PR DESCRIPTION
InstanceLabelMap was replaced with a class that handles the many-to-one mapping and internally keeps a one-to-one mapping for speed purposes.
Made _map_labels() function faster
Made _calc_iou_matrix() function faster by using joblib and not multiprocessing pool
cleaned up some imports, ...
Total speedup for "example_spine_semantic" of ~60%.