### PR TITLE
Cca backend default

### DIFF
--- a/examples/example_cfos_3d.py
+++ b/examples/example_cfos_3d.py
@@ -13,7 +13,7 @@ sample = SemanticPair(pred_masks, ref_masks)
 
 evaluator = Panoptic_Evaluator(
     expected_input=SemanticPair,
-    instance_approximator=ConnectedComponentsInstanceApproximator(cca_backend=CCABackend.cc3d),
+    instance_approximator=ConnectedComponentsInstanceApproximator(),
     instance_matcher=NaiveOneToOneMatching(),
     iou_threshold=0.5,
 )

--- a/examples/example_spine_semantic.py
+++ b/examples/example_spine_semantic.py
@@ -2,7 +2,6 @@ from auxiliary.nifti.io import read_nifti
 from auxiliary.turbopath import turbopath
 
 from panoptica import (
-    CCABackend,
     ConnectedComponentsInstanceApproximator,
     NaiveOneToOneMatching,
     Panoptic_Evaluator,
@@ -19,7 +18,7 @@ sample = SemanticPair(pred_masks, ref_masks)
 
 evaluator = Panoptic_Evaluator(
     expected_input=SemanticPair,
-    instance_approximator=ConnectedComponentsInstanceApproximator(cca_backend=CCABackend.cc3d),
+    instance_approximator=ConnectedComponentsInstanceApproximator(),
     instance_matcher=NaiveOneToOneMatching(),
     iou_threshold=0.5,
 )

--- a/panoptica/instance_approximator.py
+++ b/panoptica/instance_approximator.py
@@ -93,12 +93,12 @@ class ConnectedComponentsInstanceApproximator(InstanceApproximator):
     >>> result = cca_approximator.approximate_instances(semantic_pair)
     """
 
-    def __init__(self, cca_backend: CCABackend) -> None:
+    def __init__(self, cca_backend: CCABackend | None = None) -> None:
         """
         Initialize the ConnectedComponentsInstanceApproximator.
 
         Args:
-            cca_backend (CCABackend): The connected components algorithm backend.
+            cca_backend (CCABackend): The connected components algorithm backend. If None, will use cc3d for 3D and scipy for 1D and 2D inputs.
         """
         self.cca_backend = cca_backend
 
@@ -113,8 +113,12 @@ class ConnectedComponentsInstanceApproximator(InstanceApproximator):
         Returns:
             UnmatchedInstancePair: The result of the instance approximation.
         """
-        prediction_arr, n_prediction_instance = _connected_components(semantic_pair.prediction_arr, self.cca_backend)
-        reference_arr, n_reference_instance = _connected_components(semantic_pair.reference_arr, self.cca_backend)
+        cca_backend = self.cca_backend
+        if self.cca_backend is None:
+            cca_backend = CCABackend.cc3d if semantic_pair.n_dim >= 3 else CCABackend.scipy
+        assert cca_backend is not None
+        prediction_arr, n_prediction_instance = _connected_components(semantic_pair.prediction_arr, cca_backend)
+        reference_arr, n_reference_instance = _connected_components(semantic_pair.reference_arr, cca_backend)
         return UnmatchedInstancePair(
             prediction_arr=prediction_arr,
             reference_arr=reference_arr,

--- a/panoptica/utils/datatypes.py
+++ b/panoptica/utils/datatypes.py
@@ -20,6 +20,7 @@ class _ProcessingPair(ABC):
     # unique labels without zero
     ref_labels: tuple[int]
     pred_labels: tuple[int]
+    n_dim: int
 
     def __init__(self, prediction_arr: np.ndarray, reference_arr: np.ndarray, dtype: type | None) -> None:
         """Initializes a general Processing Pair
@@ -33,6 +34,7 @@ class _ProcessingPair(ABC):
         self.prediction_arr = prediction_arr
         self.reference_arr = reference_arr
         self.dtype = dtype
+        self.n_dim = reference_arr.ndim
         self.ref_labels: tuple[int] = tuple(_unique_without_zeros(reference_arr))  # type:ignore
         self.pred_labels: tuple[int] = tuple(_unique_without_zeros(prediction_arr))  # type:ignore
 


### PR DESCRIPTION
by default (cca_backend == None), it will use cc3d for 3D and above, and scipy for 1D and 2D
additionally, any processing_pair will save its number of dimensions (to be used for the cca stuff)