### PR TITLE
empty assd list as edge case

### DIFF
--- a/panoptica/evaluator.py
+++ b/panoptica/evaluator.py
@@ -139,6 +139,7 @@ def _handle_zero_instances_cases(
             tp=0,
             dice_list=[],
             iou_list=[],
+            assd_list=[],
         )
     if n_reference_instance == 0:
         # All references are missing, only false positives
@@ -148,6 +149,7 @@ def _handle_zero_instances_cases(
             tp=0,
             dice_list=[],
             iou_list=[],
+            assd_list=[],
         )
     if n_prediction_instance == 0:
         # All predictions are missing, only false negatives
@@ -157,5 +159,6 @@ def _handle_zero_instances_cases(
             tp=0,
             dice_list=[],
             iou_list=[],
+            assd_list=[],
         )
     return processing_pair


### PR DESCRIPTION
To prevent Exception: Evaluation failed: PanopticaResult.__init__() missing 1 required positional argument: 'assd_list' when using empty labels