### PR TITLE
Speedup instance matcher and evaluator

### DIFF
--- a/panoptica/_functionals.py
+++ b/panoptica/_functionals.py
@@ -22,15 +22,14 @@ def _calc_iou_overlapping_labels(
     max_ref = max(ref_labels) + 1
     overlap_arr = (overlap_arr * max_ref) + reference_arr
     overlap_arr[reference_arr == 0] = 0
-    overlap_labels = [i for i in np.unique(overlap_arr) if i > max_ref]
     # (ref, pred)
-    overlapping_indices = [(i % (max_ref), i // (max_ref)) for i in overlap_labels]
-    # print("overlapping_indices", overlapping_indices)
-    instance_pairs = [(reference_arr, prediction_arr, i, j) for i, j in overlapping_indices]
+    # overlapping_indices = [(i % (max_ref), i // (max_ref)) for i in np.unique(overlap_arr) if i > max_ref]
+    # instance_pairs = [(reference_arr, prediction_arr, i, j) for i, j in overlapping_indices]
+    instance_pairs = [(reference_arr, prediction_arr, i % (max_ref), i // (max_ref)) for i in np.unique(overlap_arr) if i > max_ref]
     with Pool() as pool:
         iou_values = pool.starmap(_compute_instance_iou, instance_pairs)
 
-    iou_pairs = [(i, overlapping_indices[idx]) for idx, i in enumerate(iou_values)]
+    iou_pairs = [(i, (instance_pairs[idx][2], instance_pairs[idx][3])) for idx, i in enumerate(iou_values)]
     iou_pairs = sorted(iou_pairs, key=lambda x: x[0], reverse=True)
 
     return iou_pairs

--- a/panoptica/_functionals.py
+++ b/panoptica/_functionals.py
@@ -1,10 +1,37 @@
 import numpy as np
 from panoptica.metrics import _compute_instance_iou
 from panoptica.utils.constants import CCABackend
+from panoptica.utils.numpy_utils import _get_bbox_nd
 from multiprocessing import Pool
 
 
-def _calc_iou_overlapping_labels(
+def _calc_overlapping_labels(
+    prediction_arr: np.ndarray,
+    reference_arr: np.ndarray,
+    ref_labels: tuple[int, ...],
+) -> list[tuple[int, int]]:
+    """Calculates the pairs of labels that are overlapping in at least one voxel (fast)
+
+    Args:
+        prediction_arr (np.ndarray): Numpy array containing the prediction labels.
+        reference_arr (np.ndarray): Numpy array containing the reference labels.
+        ref_labels (list[int]): List of unique reference labels.
+
+    Returns:
+        _type_: _description_
+    """
+    overlap_arr = prediction_arr.astype(np.uint32)
+    max_ref = max(ref_labels) + 1
+    overlap_arr = (overlap_arr * max_ref) + reference_arr
+    overlap_arr[reference_arr == 0] = 0
+    # overlapping_indices = [(i % (max_ref), i // (max_ref)) for i in np.unique(overlap_arr) if i > max_ref]
+    # instance_pairs = [(reference_arr, prediction_arr, i, j) for i, j in overlapping_indices]
+
+    # (ref, pred)
+    return [(i % (max_ref), i // (max_ref)) for i in np.unique(overlap_arr) if i > max_ref]
+
+
+def _calc_iou_of_overlapping_labels(
     prediction_arr: np.ndarray, reference_arr: np.ndarray, ref_labels: tuple[int, ...], pred_labels: tuple[int, ...]
 ) -> list[tuple[float, tuple[int, int]]]:
     """Calculates the IOU for all overlapping labels (fast!)
@@ -18,14 +45,14 @@ def _calc_iou_overlapping_labels(
     Returns:
         list[tuple[float, tuple[int, int]]]: List of pairs in style: (iou, (ref_label, pred_label))
     """
-    overlap_arr = prediction_arr.astype(np.uint32)
-    max_ref = max(ref_labels) + 1
-    overlap_arr = (overlap_arr * max_ref) + reference_arr
-    overlap_arr[reference_arr == 0] = 0
-    # (ref, pred)
-    # overlapping_indices = [(i % (max_ref), i // (max_ref)) for i in np.unique(overlap_arr) if i > max_ref]
-    # instance_pairs = [(reference_arr, prediction_arr, i, j) for i, j in overlapping_indices]
-    instance_pairs = [(reference_arr, prediction_arr, i % (max_ref), i // (max_ref)) for i in np.unique(overlap_arr) if i > max_ref]
+    instance_pairs = [
+        (reference_arr, prediction_arr, i[0], i[1])
+        for i in _calc_overlapping_labels(
+            prediction_arr=prediction_arr,
+            reference_arr=reference_arr,
+            ref_labels=ref_labels,
+        )
+    ]
     with Pool() as pool:
         iou_values = pool.starmap(_compute_instance_iou, instance_pairs)
 
@@ -123,3 +150,11 @@ def _connected_components(
         raise NotImplementedError(cca_backend)
 
     return cc_arr.astype(array.dtype), n_instances
+
+
+def _get_paired_crop(prediction_arr: np.ndarray, reference_arr: np.ndarray, px_pad: int = 2):
+    assert prediction_arr.shape == reference_arr.shape
+    bbox1 = _get_bbox_nd(prediction_arr, px_dist=px_pad)
+    bbox2 = _get_bbox_nd(reference_arr, px_dist=px_pad)
+
+    return tuple(slice(min(bbox1[idx].start, bbox2[idx].start), max(bbox1[idx].stop, bbox2[idx].stop)) for idx in range(len(bbox1)))

--- a/panoptica/evaluator.py
+++ b/panoptica/evaluator.py
@@ -99,6 +99,9 @@ def panoptic_evaluate(
         print("-- Input was Panoptic Result, will just return")
         return processing_pair, debug_data
 
+    # Crops away unecessary space of zeroes
+    processing_pair.crop_data()
+
     if isinstance(processing_pair, SemanticPair):
         assert instance_approximator is not None, "Got SemanticPair but not InstanceApproximator"
         print("-- Got SemanticPair, will approximate instances")

--- a/panoptica/instance_approximator.py
+++ b/panoptica/instance_approximator.py
@@ -66,7 +66,7 @@ class InstanceApproximator(ABC):
         # Call algorithm
         instance_pair = self._approximate_instances(semantic_pair, **kwargs)
         # Check validity
-        pred_labels, ref_labels = instance_pair.pred_labels, instance_pair.ref_labels
+        pred_labels, ref_labels = instance_pair._pred_labels, instance_pair._ref_labels
         pred_label_range = (np.min(pred_labels), np.max(pred_labels)) if len(pred_labels) > 0 else (0, 0)
         ref_label_range = (np.min(ref_labels), np.max(ref_labels)) if len(ref_labels) > 0 else (0, 0)
         #
@@ -75,8 +75,8 @@ class InstanceApproximator(ABC):
         # Set dtype to smalles fitting uint
         max_value = max(np.max(pred_label_range[1]), np.max(ref_label_range[1]))
         dtype = _get_smallest_fitting_uint(max_value)
-        instance_pair.prediction_arr.astype(dtype)
-        instance_pair.reference_arr.astype(dtype)
+        instance_pair._prediction_arr.astype(dtype)
+        instance_pair._reference_arr.astype(dtype)
         return instance_pair
 
 
@@ -124,13 +124,15 @@ class ConnectedComponentsInstanceApproximator(InstanceApproximator):
             cca_backend = CCABackend.cc3d if semantic_pair.n_dim >= 3 else CCABackend.scipy
         assert cca_backend is not None
 
-        empty_prediction = len(semantic_pair.pred_labels) == 0
-        empty_reference = len(semantic_pair.ref_labels) == 0
+        empty_prediction = len(semantic_pair._pred_labels) == 0
+        empty_reference = len(semantic_pair._ref_labels) == 0
         prediction_arr, n_prediction_instance = (
-            _connected_components(semantic_pair.prediction_arr, cca_backend) if not empty_prediction else (semantic_pair.prediction_arr, 0)
+            _connected_components(semantic_pair._prediction_arr, cca_backend)
+            if not empty_prediction
+            else (semantic_pair._prediction_arr, 0)
         )
         reference_arr, n_reference_instance = (
-            _connected_components(semantic_pair.reference_arr, cca_backend) if not empty_reference else (semantic_pair.reference_arr, 0)
+            _connected_components(semantic_pair._reference_arr, cca_backend) if not empty_reference else (semantic_pair._reference_arr, 0)
         )
         return UnmatchedInstancePair(
             prediction_arr=prediction_arr,

--- a/panoptica/instance_matcher.py
+++ b/panoptica/instance_matcher.py
@@ -119,28 +119,9 @@ class NaiveThresholdMatching(InstanceMatchingAlgorithm):
         """
         ref_labels = unmatched_instance_pair._ref_labels
         pred_labels = unmatched_instance_pair._pred_labels
-        # TODO bounding boxes first, then only calc iou over bboxes collisions
-        # iou_matrix = _calc_iou_matrix(
-        #    unmatched_instance_pair.prediction_arr.flatten(),
-        #    unmatched_instance_pair.reference_arr.flatten(),
-        #    ref_labels,
-        #    pred_labels,
-        # )
-        # Use linear_sum_assignment to find the best matches
-        # ref_indices, pred_indices = linear_sum_assignment(-iou_matrix)
 
         # Initialize variables for True Positives (tp) and False Positives (fp)
         labelmap = InstanceLabelMap()
-
-        # Loop through matched instances to compute PQ components
-        # for ref_idx, pred_idx in zip(ref_indices, pred_indices):
-        #    if labelmap.contains_or(pred_labels[pred_idx], ref_labels[ref_idx]) and not self.allow_many_to_one:
-        #        continue  # -> doesnt make speed difference
-        #    iou = iou_matrix[ref_idx][pred_idx]
-        #    if iou >= self.iou_threshold:
-        #        # Match found, increment true positive count and collect IoU and Dice values
-        #        labelmap.add_labelmap_entry(pred_labels[pred_idx], ref_labels[ref_idx])
-        # map label ref_idx to pred_idx
 
         pred_arr, ref_arr = unmatched_instance_pair._prediction_arr, unmatched_instance_pair._reference_arr
         iou_pairs = _calc_iou_of_overlapping_labels(pred_arr, ref_arr, ref_labels, pred_labels)

--- a/panoptica/instance_matcher.py
+++ b/panoptica/instance_matcher.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
-from panoptica._functionals import _calc_iou_matrix, _map_labels, _calc_iou_overlapping_labels
+from panoptica._functionals import _calc_iou_matrix, _map_labels, _calc_iou_of_overlapping_labels
 from panoptica.utils.datatypes import (
     InstanceLabelMap,
     MatchedInstancePair,
@@ -117,8 +117,8 @@ class NaiveThresholdMatching(InstanceMatchingAlgorithm):
         Returns:
             Instance_Label_Map: The result of the instance matching.
         """
-        ref_labels = unmatched_instance_pair.ref_labels
-        pred_labels = unmatched_instance_pair.pred_labels
+        ref_labels = unmatched_instance_pair._ref_labels
+        pred_labels = unmatched_instance_pair._pred_labels
         # TODO bounding boxes first, then only calc iou over bboxes collisions
         # iou_matrix = _calc_iou_matrix(
         #    unmatched_instance_pair.prediction_arr.flatten(),
@@ -142,8 +142,8 @@ class NaiveThresholdMatching(InstanceMatchingAlgorithm):
         #        labelmap.add_labelmap_entry(pred_labels[pred_idx], ref_labels[ref_idx])
         # map label ref_idx to pred_idx
 
-        pred_arr, ref_arr = unmatched_instance_pair.prediction_arr, unmatched_instance_pair.reference_arr
-        iou_pairs = _calc_iou_overlapping_labels(pred_arr, ref_arr, ref_labels, pred_labels)
+        pred_arr, ref_arr = unmatched_instance_pair._prediction_arr, unmatched_instance_pair._reference_arr
+        iou_pairs = _calc_iou_of_overlapping_labels(pred_arr, ref_arr, ref_labels, pred_labels)
 
         # Loop through matched instances to compute PQ components
         for iou, (ref_label, pred_label) in iou_pairs:
@@ -172,10 +172,10 @@ def map_instance_labels(processing_pair: UnmatchedInstancePair, labelmap: Instan
     >>> labelmap = [([1, 2], [3, 4]), ([5], [6])]
     >>> result = map_instance_labels(unmatched_instance_pair, labelmap)
     """
-    prediction_arr = processing_pair.prediction_arr
+    prediction_arr = processing_pair._prediction_arr
 
-    ref_labels = processing_pair.ref_labels
-    pred_labels = processing_pair.pred_labels
+    ref_labels = processing_pair._ref_labels
+    pred_labels = processing_pair._pred_labels
 
     ref_matched_labels = []
     label_counter = max(ref_labels) + 1
@@ -200,7 +200,7 @@ def map_instance_labels(processing_pair: UnmatchedInstancePair, labelmap: Instan
     # Build a MatchedInstancePair out of the newly derived data
     matched_instance_pair = MatchedInstancePair(
         prediction_arr=prediction_arr_relabeled,
-        reference_arr=processing_pair.reference_arr,
+        reference_arr=processing_pair._reference_arr,
         missed_reference_labels=missed_ref_labels,
         missed_prediction_labels=missed_pred_labels,
         n_prediction_instance=processing_pair.n_prediction_instance,

--- a/panoptica/utils/numpy_utils.py
+++ b/panoptica/utils/numpy_utils.py
@@ -1,5 +1,6 @@
 import warnings
 import numpy as np
+import itertools
 
 
 def _unique_without_zeros(arr: np.ndarray) -> np.ndarray:
@@ -59,3 +60,35 @@ def _get_smallest_fitting_uint(max_value: int) -> type:
     else:
         dtype = np.uint64
     return dtype
+
+
+def _get_bbox_nd(img: np.ndarray, px_dist: int | tuple[int, ...] = 0) -> tuple[slice, ...]:
+    """calculates a bounding box in n dimensions given a image (factor ~2 times faster than compute_crop_slice)
+
+    Args:
+        img: input array
+        px_dist: int | tuple[int]: dist (int): The amount of padding to be added to the cropped image. If int, will apply the same padding to each dim. Default value is 0.
+
+    Returns:
+        list of boundary coordinates [x_min, x_max, y_min, y_max, z_min, z_max]
+    """
+    assert img is not None, "bbox_nd: received None as image"
+    assert np.count_nonzero(img) > 0, "bbox_nd: img is empty, cannot calculate a bbox"
+    N = img.ndim
+    shp = img.shape
+    if isinstance(px_dist, int):
+        px_dist = np.ones(N, dtype=np.uint8) * px_dist
+    assert len(px_dist) == N, f"dimension mismatch, got img shape {shp} and px_dist {px_dist}"
+
+    out = []
+    for ax in itertools.combinations(reversed(range(N)), N - 1):
+        nonzero = np.any(a=img, axis=ax)
+        out.extend(np.where(nonzero)[0][[0, -1]])
+    out = tuple(
+        slice(
+            max(out[i] - px_dist[i // 2], 0),
+            min(out[i + 1] + px_dist[i // 2], shp[i // 2]) + 1,
+        )
+        for i in range(0, len(out), 2)
+    )
+    return out


### PR DESCRIPTION
Added cropping as pre-processing step, which makes instance matching and especially evaluation a lot faster.
Made instance matcher faster by quickly calculating which pairs overlap at all and only calculate the metric over those pairs.