### PR TITLE
Fix Verbose and make Citation Reminder only appeare once

### DIFF
--- a/panoptica/panoptic_evaluator.py
+++ b/panoptica/panoptic_evaluator.py
@@ -82,7 +82,8 @@ class Panoptic_Evaluator:
             decision_threshold=self.__decision_threshold,
             result_all=result_all,
             log_times=self.__log_times,
-            verbose=self.__verbose if verbose is None else verbose,
+            verbose=True if verbose is None else verbose,
+            verbose_calc=self.__verbose if verbose is None else verbose,
         )
 
 
@@ -98,7 +99,8 @@ def panoptic_evaluate(
     edge_case_handler: EdgeCaseHandler | None = None,
     log_times: bool = False,
     result_all: bool = True,
-    verbose: bool = True,
+    verbose=False,
+    verbose_calc=False,
     **kwargs,
 ) -> tuple[PanopticaResult, dict[str, _ProcessingPair]]:
     """
@@ -202,7 +204,7 @@ def panoptic_evaluate(
 
     if isinstance(processing_pair, PanopticaResult):
         if result_all:
-            processing_pair.calculate_all(print_errors=verbose)
+            processing_pair.calculate_all(print_errors=verbose_calc)
         return processing_pair, debug_data
 
     raise RuntimeError("End of panoptic pipeline reached without results")

--- a/panoptica/panoptic_evaluator.py
+++ b/panoptica/panoptic_evaluator.py
@@ -98,7 +98,7 @@ def panoptic_evaluate(
     edge_case_handler: EdgeCaseHandler | None = None,
     log_times: bool = False,
     result_all: bool = True,
-    verbose: bool = False,
+    verbose: bool = True,
     **kwargs,
 ) -> tuple[PanopticaResult, dict[str, _ProcessingPair]]:
     """
@@ -128,14 +128,16 @@ def panoptic_evaluate(
     >>> panoptic_evaluate(SemanticPair(...), instance_approximator=InstanceApproximator(), iou_threshold=0.6)
     (PanopticaResult(...), {'UnmatchedInstanceMap': _ProcessingPair(...), 'MatchedInstanceMap': _ProcessingPair(...)})
     """
-    print("Panoptic: Start Evaluation")
+    if verbose:
+        print("Panoptic: Start Evaluation")
     if edge_case_handler is None:
         # use default edgecase handler
         edge_case_handler = EdgeCaseHandler()
     debug_data: dict[str, _ProcessingPair] = {}
     # First Phase: Instance Approximation
     if isinstance(processing_pair, PanopticaResult):
-        print("-- Input was Panoptic Result, will just return")
+        if verbose:
+            print("-- Input was Panoptic Result, will just return")
         return processing_pair, debug_data
 
     # Crops away unecessary space of zeroes
@@ -145,7 +147,8 @@ def panoptic_evaluate(
         assert (
             instance_approximator is not None
         ), "Got SemanticPair but not InstanceApproximator"
-        print("-- Got SemanticPair, will approximate instances")
+        if verbose:
+            print("-- Got SemanticPair, will approximate instances")
         processing_pair = instance_approximator.approximate_instances(processing_pair)
         start = perf_counter()
         processing_pair = instance_approximator.approximate_instances(processing_pair)
@@ -162,7 +165,8 @@ def panoptic_evaluate(
         )
 
     if isinstance(processing_pair, UnmatchedInstancePair):
-        print("-- Got UnmatchedInstancePair, will match instances")
+        if verbose:
+            print("-- Got UnmatchedInstancePair, will match instances")
         assert (
             instance_matcher is not None
         ), "Got UnmatchedInstancePair but not InstanceMatchingAlgorithm"
@@ -184,7 +188,8 @@ def panoptic_evaluate(
         )
 
     if isinstance(processing_pair, MatchedInstancePair):
-        print("-- Got MatchedInstancePair, will evaluate instances")
+        if verbose:
+            print("-- Got MatchedInstancePair, will evaluate instances")
         processing_pair = evaluate_matched_instance(
             processing_pair,
             eval_metrics=eval_metrics,

--- a/panoptica/timing.py
+++ b/panoptica/timing.py
@@ -9,7 +9,8 @@ def measure_time(func):
         result = func(*args, **kwargs)
         end_time = time.time()
         elapsed_time = end_time - start_time
-        print(f"-- {func.__name__} took {elapsed_time} seconds to execute.")
+        if hasattr(kwargs, "verbose") and getattr(kwargs, "verbose"):
+            print(f"-- {func.__name__} took {elapsed_time} seconds to execute.")
         return result
 
     return wrapper

--- a/panoptica/utils/citation_reminder.py
+++ b/panoptica/utils/citation_reminder.py
@@ -13,7 +13,7 @@ def citation_reminder(func):
             console = Console()
             console.rule("Thank you for using [bold]panoptica[/bold]")
             console.print(
-                f"Please support our development by citing",
+                "Please support our development by citing",
                 justify="center",
             )
             console.print(
@@ -22,6 +22,7 @@ def citation_reminder(func):
             )
             console.rule()
             console.line()
+            os.environ["PANOPTICA_CITATION_REMINDER"] = "false"  # Show only once
         return func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Every "evaluate" call was printing the citation reminder, and setting verbose=False still prints a lot of stuff on the console.

Changed that "verbose = False" removes all printouts. Except that the Citation Reminder is printed once. I keep the default behavior. Now verbose has 3 modes False, True, and None (default)

