### PR TITLE
Add a logger and refactor the I/O and pipeline modules

### DIFF
--- a/panoptica/panoptica_aggregator.py
+++ b/panoptica/panoptica_aggregator.py
@@ -1,4 +1,7 @@
-from panoptica.utils import format_instance_subject_name, validate_subject_name
+"""Thread-safe aggregation of per-subject evaluation results into a TSV/JSONL file."""
+
+from panoptica.utils import validate_subject_name
+from panoptica.utils.logger import logger
 import numpy as np
 from panoptica.panoptica_statistics import Panoptica_Statistic
 from panoptica.panoptica_evaluator import Panoptica_Evaluator
@@ -9,7 +12,6 @@ import os
 import atexit
 from tempfile import NamedTemporaryFile
 import warnings
-from typing import Optional
 
 from panoptica.utils import FileType
 from panoptica.utils.file_backend import COMPUTATION_TIME_KEY
@@ -48,7 +50,7 @@ class Panoptica_Aggregator:
         file_type: FileType = "jsonl",
         output_individual_instance_metrics: bool = False,
         is_autc: bool = False,
-        threshold_step_size: Optional[float] = None,
+        threshold_step_size: float | None = None,
     ):
         """Initializes the Panoptica_Aggregator.
 
@@ -175,15 +177,14 @@ class Panoptica_Aggregator:
             id_list = _load_buffer_entries(self.__output_buffer_file)
 
             if subject_name in id_list:
-                print(
-                    f"Subject '{subject_name}' evaluated or in process {self.__output_file}, do not add duplicates to your evaluation!",
-                    flush=True,
+                logger.warning(
+                    f"Subject '{subject_name}' evaluated or in process {self.__output_file}, do not add duplicates to your evaluation!"
                 )
                 return
             _append_buffer_entries(self.__output_buffer_file, [subject_name])
 
         # Run Evaluation (allowed in parallel)
-        print(f"Call evaluate on {subject_name}")
+        logger.info(f"Call evaluate on {subject_name}")
         if self.__autc:
             if self.__threshold_step_size is None:
                 raise ValueError(
@@ -232,7 +233,7 @@ def _load_buffer_entries(file: str | Path) -> list[str]:
     Raises:
         ValueError: If the buffer file contains duplicate entries.
     """
-    with open(str(file), "r", encoding="utf8", newline="") as f:
+    with open(str(file), encoding="utf8", newline="") as f:
         rows = list(csv.reader(f, delimiter="\t", lineterminator="\n"))
     entries = [row[0] for row in rows if row]
     if len(entries) != len(set(entries)):

--- a/panoptica/panoptica_pipeline.py
+++ b/panoptica/panoptica_pipeline.py
@@ -1,5 +1,7 @@
-from typing import Optional
+"""The three-phase panoptic evaluation pipeline: approximation, matching, evaluation."""
+
 from time import perf_counter
+from panoptica.utils.logger import logger
 from typing import TYPE_CHECKING
 
 from panoptica.instance_approximator import InstanceApproximator
@@ -19,18 +21,26 @@ from panoptica.utils.processing_pair import (
 from panoptica._functionals import _get_voronoi_regions
 import numpy as np
 
+# A processing pair is progressively transformed across the pipeline phases; the
+# isinstance guards in each phase narrow it back to the concrete type they handle.
+_ProcessingState = (
+    SemanticPair
+    | UnmatchedInstancePair
+    | MatchedInstancePair
+    | EvaluateInstancePair
+    | PanopticaResult
+)
+
 if TYPE_CHECKING:
-    import torch
-    import SimpleITK as sitk
-    import nibabel as nib
+    pass
 
 
 def _panoptic_evaluate(
     input_pair: SemanticPair | UnmatchedInstancePair | MatchedInstancePair,
     instance_approximator: InstanceApproximator | None = None,
     instance_matcher: InstanceMatchingAlgorithm | None = None,
-    instance_metrics: list[Metric] = [Metric.DSC, Metric.IOU, Metric.ASSD],
-    global_metrics: list[Metric] = [Metric.DSC],
+    instance_metrics: list[Metric] | None = None,
+    global_metrics: list[Metric] | None = None,
     decision_metric: Metric | None = None,
     decision_threshold: float | None = None,
     matching_threshold: float | None = None,
@@ -69,8 +79,12 @@ def _panoptic_evaluate(
         ValueError: If a required component (e.g. InstanceApproximator or InstanceMatchingAlgorithm) is missing.
         RuntimeError: If the end of the panoptic pipeline is reached without producing results.
     """
+    if instance_metrics is None:
+        instance_metrics = [Metric.DSC, Metric.IOU, Metric.ASSD]
+    if global_metrics is None:
+        global_metrics = [Metric.DSC]
     if verbose:
-        print("Panoptic: Start Evaluation")
+        logger.info("Panoptic: Start Evaluation")
     if edge_case_handler is None:
         edge_case_handler = EdgeCaseHandler()
 
@@ -86,7 +100,7 @@ def _panoptic_evaluate(
     # Get metadata directly from the processing pair as a dictionary
     instance_metadata = input_pair.get_metadata()
 
-    processing_pair = input_pair.copy()
+    processing_pair: _ProcessingState = input_pair.copy()
 
     # First Phase: Instance Approximation
     processing_pair = _phase_instance_approximation(
@@ -188,8 +202,8 @@ def _panoptic_evaluate_region_wise(
     input_pair: SemanticPair | UnmatchedInstancePair,
     instance_approximator: InstanceApproximator | None = None,
     instance_matcher: InstanceMatchingAlgorithm | None = None,
-    instance_metrics: list[Metric] = [Metric.DSC, Metric.IOU, Metric.ASSD],
-    global_metrics: list[Metric] = [Metric.DSC],
+    instance_metrics: list[Metric] | None = None,
+    global_metrics: list[Metric] | None = None,
     edge_case_handler: EdgeCaseHandler | None = None,
     log_times: bool = False,
     result_all: bool = True,
@@ -223,8 +237,12 @@ def _panoptic_evaluate_region_wise(
         ValueError: If a required component (e.g. InstanceApproximator or InstanceMatchingAlgorithm) is missing.
         RuntimeError: If the end of the panoptic pipeline is reached without producing results.
     """
+    if instance_metrics is None:
+        instance_metrics = [Metric.DSC, Metric.IOU, Metric.ASSD]
+    if global_metrics is None:
+        global_metrics = [Metric.DSC]
     if verbose:
-        print("Panoptic: Start Evaluation")
+        logger.info("Panoptic: Start Evaluation")
     if edge_case_handler is None:
         edge_case_handler = EdgeCaseHandler()
 
@@ -240,7 +258,7 @@ def _panoptic_evaluate_region_wise(
     # Get metadata directly from the processing pair as a dictionary
     instance_metadata = input_pair.get_metadata()
 
-    processing_pair = input_pair.copy()
+    processing_pair: _ProcessingState = input_pair.copy()
 
     # First Phase: Instance Approximation
     processing_pair = _phase_instance_approximation(
@@ -265,7 +283,6 @@ def _panoptic_evaluate_region_wise(
 
     # proceed if pipeline only if no edge case handling necessary
     if not isinstance(processing_pair, PanopticaResult):
-
         # create regions and label to regions
         region_map, num_features = _get_voronoi_regions(
             processing_pair.reference_arr, processing_pair.n_ref_instances
@@ -285,7 +302,7 @@ def _panoptic_evaluate_region_wise(
             )
 
             # multiply region mask with both prediction and reference arr
-            processing_pair_r = UnmatchedInstancePair(
+            processing_pair_r: _ProcessingState = UnmatchedInstancePair(
                 processing_pair.prediction_arr * region_mask,
                 processing_pair.reference_arr * region_mask,
             )
@@ -383,11 +400,11 @@ def _panoptic_evaluate_region_wise(
                 reference_arr=input_pair.reference_arr,
                 prediction_arr=input_pair.prediction_arr,
                 processing_pair_orig_shape=instance_metadata["original_shape"],
-                n_pred_instances=np.nan,
-                n_ref_instances=np.nan,  # We set n_ref_instances to the number of regions, as each region corresponds to one reference instance
+                n_pred_instances=np.nan,  # type: ignore[arg-type]
+                n_ref_instances=np.nan,  # type: ignore[arg-type]  # We set n_ref_instances to the number of regions, as each region corresponds to one reference instance
                 n_ref_labels=instance_metadata["n_ref_labels"],
                 label_group=label_group,
-                tp=np.nan,
+                tp=np.nan,  # type: ignore[arg-type]
                 list_metrics={},
                 global_metrics=global_metrics,
                 edge_case_handler=edge_case_handler,
@@ -397,11 +414,10 @@ def _panoptic_evaluate_region_wise(
     else:
         # In case edge case handling already produced a result, we skip the region-wise processing and return the edge case result directly
         combined_result = processing_pair
-        combined_result.tp = (
-            np.nan
-        )  # Set tp to nan to indicate that no true positive calculation was done
-        combined_result.n_pred_instances = np.nan
-        combined_result.n_ref_instances = np.nan
+        # region-wise has no global TP/instance counts
+        combined_result.tp = np.nan  # type: ignore[assignment]
+        combined_result.n_pred_instances = np.nan  # type: ignore[assignment]
+        combined_result.n_ref_instances = np.nan  # type: ignore[assignment]
         num_features = 0
 
     # combined global metrics post-hoc
@@ -427,9 +443,9 @@ def _panoptic_evaluate_region_wise(
 
 
 def _phase_instance_approximation(
-    processing_pair: SemanticPair,
-    intermediate_steps_data: Optional[IntermediateStepsData],
-    instance_approximator: InstanceApproximator,
+    processing_pair: _ProcessingState,
+    intermediate_steps_data: IntermediateStepsData | None,
+    instance_approximator: InstanceApproximator | None,
     instance_metadata: dict,
     label_group=None,
     log_times=False,
@@ -444,7 +460,7 @@ def _phase_instance_approximation(
         if instance_approximator is None:
             raise ValueError("Got SemanticPair but not InstanceApproximator")
         if verbose:
-            print("-- Got SemanticPair, will approximate instances")
+            logger.info("-- Got SemanticPair, will approximate instances")
         start = perf_counter()
 
         processing_pair = instance_approximator.approximate_instances(
@@ -453,7 +469,7 @@ def _phase_instance_approximation(
         )
 
         if log_times:
-            print(f"-- Approximation took {perf_counter() - start} seconds")
+            logger.info(f"-- Approximation took {perf_counter() - start} seconds")
 
         # Update instance metadata after approximation
         if isinstance(processing_pair, (UnmatchedInstancePair, MatchedInstancePair)):
@@ -464,13 +480,13 @@ def _phase_instance_approximation(
 
 
 def _phase_instance_matching(
-    processing_pair: UnmatchedInstancePair,
+    processing_pair: _ProcessingState,
     intermediate_steps_data: IntermediateStepsData,
     instance_metrics: list[Metric],
     instance_metadata: dict,
     global_metrics: list[Metric],
     edge_case_handler: EdgeCaseHandler,
-    instance_matcher: InstanceMatchingAlgorithm,
+    instance_matcher: InstanceMatchingAlgorithm | None,
     matching_threshold: float | None = None,
     label_group=None,
     log_times=False,
@@ -492,7 +508,7 @@ def _phase_instance_matching(
 
     if isinstance(processing_pair, UnmatchedInstancePair):
         if verbose:
-            print("-- Got UnmatchedInstancePair, will match instances")
+            logger.info("-- Got UnmatchedInstancePair, will match instances")
         if instance_matcher is None:
             raise ValueError(
                 "Got UnmatchedInstancePair but not InstanceMatchingAlgorithm"
@@ -513,12 +529,12 @@ def _phase_instance_matching(
             **match_kwargs,
         )
         if log_times:
-            print(f"-- Matching took {perf_counter() - start} seconds")
+            logger.info(f"-- Matching took {perf_counter() - start} seconds")
     return processing_pair
 
 
 def _phase_instance_evaluation(
-    processing_pair: UnmatchedInstancePair | MatchedInstancePair,
+    processing_pair: _ProcessingState,
     intermediate_steps_data: IntermediateStepsData,
     instance_metrics: list[Metric],
     instance_metadata: dict,
@@ -545,7 +561,7 @@ def _phase_instance_evaluation(
 
     if isinstance(processing_pair, MatchedInstancePair):
         if verbose:
-            print("-- Got MatchedInstancePair, will evaluate instances")
+            logger.info("-- Got MatchedInstancePair, will evaluate instances")
         start = perf_counter()
         processing_pair = evaluate_matched_instance(
             processing_pair,
@@ -557,7 +573,7 @@ def _phase_instance_evaluation(
             **kwargs,
         )
         if log_times:
-            print(f"-- Instance Evaluation took {perf_counter() - start} seconds")
+            logger.info(f"-- Instance Evaluation took {perf_counter() - start} seconds")
     return processing_pair
 
 
@@ -565,7 +581,7 @@ def _handle_zero_instances_cases(
     processing_pair: UnmatchedInstancePair | MatchedInstancePair,
     edge_case_handler: EdgeCaseHandler,
     global_metrics: list[Metric],
-    eval_metrics: list[Metric] = [Metric.DSC, Metric.IOU, Metric.ASSD],
+    eval_metrics: list[Metric] | None = None,
     voxelspacing: tuple[float, ...] | None = None,
 ) -> UnmatchedInstancePair | MatchedInstancePair | PanopticaResult:
     """
@@ -581,6 +597,8 @@ def _handle_zero_instances_cases(
     Returns:
         UnmatchedInstancePair | MatchedInstancePair | PanopticaResult: The processed processing pair or evaluation result.
     """
+    if eval_metrics is None:
+        eval_metrics = [Metric.DSC, Metric.IOU, Metric.ASSD]
     n_reference_instance = processing_pair.n_ref_instances
     n_prediction_instance = processing_pair.n_pred_instances
 

--- a/panoptica/panoptica_result.py
+++ b/panoptica/panoptica_result.py
@@ -1,24 +1,31 @@
+"""The PanopticaResult container and its lazy, dependency-aware metric computation."""
+
 from __future__ import annotations
-from typing import Any, Callable
+
+from collections.abc import Callable
+from panoptica.utils.logger import logger
+from typing import Any
+
 import numpy as np
-from panoptica.metrics import MetricMode
+
+from panoptica._functionals import _get_orig_onehotcc_structure
+from panoptica.metrics import (
+    Evaluation_List_Metric,
+    Evaluation_Metric,
+    Metric,
+    MetricCouldNotBeComputedException,
+    MetricMode,
+    MetricType,
+)
+from panoptica.utils.edge_case_handling import EdgeCaseHandler
+from panoptica.utils.label_group import LabelGroup, LabelPartGroup
+from panoptica.utils.processing_pair import IntermediateStepsData
 from panoptica.utils.serialization import (
     _AUTC_PREFIX,
     format_autc_key,
     format_threshold_key,
     is_autc_key,
 )
-from panoptica.metrics import (
-    Evaluation_List_Metric,
-    Evaluation_Metric,
-    Metric,
-    MetricCouldNotBeComputedException,
-    MetricType,
-)
-from panoptica.utils.edge_case_handling import EdgeCaseHandler
-from panoptica.utils.processing_pair import IntermediateStepsData
-from panoptica.utils.label_group import LabelGroup, LabelPartGroup
-from panoptica._functionals import _get_orig_onehotcc_structure
 
 # ``np.trapezoid`` was added in NumPy 2.0 as the rename of ``np.trapz`` (which is
 # deprecated there but still present). Resolve whichever exists so AUTC integration
@@ -26,8 +33,7 @@ from panoptica._functionals import _get_orig_onehotcc_structure
 _trapezoid = getattr(np, "trapezoid", None) or np.trapz
 
 
-class PanopticaResult(object):
-
+class PanopticaResult:
     def __init__(
         self,
         reference_arr: np.ndarray,
@@ -37,7 +43,7 @@ class PanopticaResult(object):
         tp: int,
         list_metrics: dict[Metric, list[float]],
         edge_case_handler: EdgeCaseHandler,
-        global_metrics: list[Metric] = [],
+        global_metrics: list[Metric] | None = None,
         processing_pair_orig_shape: tuple[int, int] | None = None,
         n_ref_labels: int | None = None,
         label_group: LabelGroup | None = None,
@@ -63,12 +69,15 @@ class PanopticaResult(object):
         self._evaluation_metrics: dict[str, Evaluation_Metric] = {}
         self._edge_case_handler = edge_case_handler
         empty_list_std = self._edge_case_handler.handle_empty_list_std().value
+        if global_metrics is None:
+            global_metrics = []
         self._global_metrics: list[Metric] = global_metrics
         self.computation_time = computation_time
         self.intermediate_steps_data = intermediate_steps_data
         self.metadata: dict[str, Any] = kwargs
 
         if isinstance(label_group, LabelPartGroup):
+            assert n_ref_labels is not None and processing_pair_orig_shape is not None
             # Store the one-hot encoded arrays for both reference and prediction
             one_hot_ref_array = _get_orig_onehotcc_structure(
                 reference_arr, n_ref_labels, processing_pair_orig_shape
@@ -78,7 +87,7 @@ class PanopticaResult(object):
             )
 
             # Store the multi-channel data for later use in global metrics
-            self._multi_channel_data = {
+            self._multi_channel_data: dict[str, Any] = {
                 "ref_channels": one_hot_ref_array,
                 "pred_channels": one_hot_pred_array,
                 "n_channels": one_hot_ref_array.shape[0],
@@ -503,7 +512,7 @@ class PanopticaResult(object):
             self._add_metric(
                 f"global_bin_{m.name.lower()}",
                 MetricType.GLOBAL,
-                lambda x: MetricCouldNotBeComputedException(
+                lambda x, m=m: MetricCouldNotBeComputedException(
                     f"Global Metric {m} not set"
                 ),
                 long_name="Global Binary " + m.value.long_name,
@@ -514,7 +523,7 @@ class PanopticaResult(object):
             self._add_metric(
                 f"region_avg_{m.name.lower()}",
                 MetricType.GLOBAL,
-                lambda x: MetricCouldNotBeComputedException(
+                lambda x, m=m: MetricCouldNotBeComputedException(
                     f"Region Average Metric {m} not set"
                 ),
                 long_name="Region Average " + m.value.long_name,
@@ -621,7 +630,7 @@ class PanopticaResult(object):
 
             # Return mean of channel metrics
             if channel_metrics:
-                return np.mean(channel_metrics)
+                return float(np.mean(channel_metrics))  # type: ignore[arg-type]
             else:
                 # Handle case where no valid metrics could be computed
                 is_edgecase, result = self._edge_case_handler.handle_zero_tp(
@@ -706,15 +715,17 @@ class PanopticaResult(object):
         """
         metric_errors: dict[str, Exception] = {}
 
-        for k, v in self._evaluation_metrics.items():
+        for k in self._evaluation_metrics:
             try:
-                v = getattr(self, k)
+                # Access each metric to trigger its lazy computation; we only care
+                # about which ones raise, not their values.
+                getattr(self, k)
             except Exception as e:
                 metric_errors[k] = e
 
         if print_errors:
-            for k, v in metric_errors.items():
-                print(f"Metric {k}: {v}")
+            for k, err in metric_errors.items():
+                logger.warning(f"Metric {k}: {err}")
 
     def _calc(self, k, v):
         """
@@ -811,13 +822,13 @@ class PanopticaResult(object):
                     val_list[i] if i < len(val_list) else None
                 )
 
-        for key, val_list in (
+        for key, val_list in (  # type: ignore[assignment]
             ("voxel_count", self.instance_voxel_count_matched_ref_list),
             ("volume", self.instance_volume_matched_ref_list),
         ):
             for i in range(n_matched):
                 rows[i][key] = val_list[i] if i < len(val_list) else None
-        for key, val_list in (
+        for key, val_list in (  # type: ignore[assignment]
             ("voxel_count", self.instance_voxel_count_unmatched_ref_list),
             ("volume", self.instance_volume_unmatched_ref_list),
         ):
@@ -949,7 +960,7 @@ class PanopticaResult(object):
 
 
 # region AUTCResult
-class PanopticaAUTCResult(object):
+class PanopticaAUTCResult:
     """
     Holds dict mapping thresholds across a range to PanopticaResult objects.
     Computes Area Under The Threshold Curve (AUTC) for metrics from different thresholds.
@@ -996,7 +1007,7 @@ class PanopticaAUTCResult(object):
             if np.isclose(t, threshold):
                 return res
         raise ValueError(
-            f"No result for threshold {threshold}. " f"Available: {self.thresholds}"
+            f"No result for threshold {threshold}. Available: {self.thresholds}"
         )
 
     def get_autc(self, metric_name: str) -> float:
@@ -1022,7 +1033,7 @@ class PanopticaAUTCResult(object):
             )
 
         y_values: list[float] = []
-        for threshold, result in self._threshold_results.items():
+        for _threshold, result in self._threshold_results.items():
             try:
                 val = getattr(result, metric_name)
                 y_values.append(0.0 if (val is None or np.isnan(val)) else float(val))
@@ -1089,7 +1100,7 @@ class PanopticaAUTCResult(object):
                 raise AttributeError(
                     f"'{type(self).__name__}' has no attribute '{name}' "
                     f"(metric '{metric_name}' not found in PanopticaResult)."
-                )
+                ) from None
 
         raise AttributeError(
             f"'{type(self).__name__}' object has no attribute '{name}'"

--- a/panoptica/panoptica_statistics.py
+++ b/panoptica/panoptica_statistics.py
@@ -1,3 +1,5 @@
+"""Aggregate statistics and plots computed over many PanopticaResult evaluations."""
+
 from panoptica.utils import (
     is_threshold_key,
     parse_threshold_key,
@@ -6,6 +8,7 @@ from panoptica.utils import (
     get_backend,
     FileType,
 )
+from panoptica.utils.logger import logger
 import numpy as np
 import warnings
 from pathlib import Path
@@ -16,8 +19,9 @@ try:
     import plotly.express as px
     import plotly.graph_objects as go
 except Exception as e:
-    print(e)
-    print("OPTIONAL PACKAGE MISSING")
+    logger.warning(
+        "Optional plotting package missing, some statistics features disabled: %s", e
+    )
 
 
 class FloatDistribution:
@@ -338,10 +342,10 @@ class Panoptica_Statistic:
         """Gets the values for ONE subject for each group and metric
 
         Args:
-            subjectname (str): _description_
+            subjectname (str): Name of the subject to extract.
 
         Returns:
-            _type_: _description_
+            dict[str, dict[str, float | None]]: Group -> metric -> value for this subject.
         """
         self._assertsubject(subjectname)
         sidx = self.__subj_names.index(subjectname)
@@ -354,10 +358,10 @@ class Panoptica_Statistic:
         """Gets the dictionary mapping the group to the metrics specified
 
         Args:
-            metricname (str): _description_
+            metricname (str): Name of the metric to extract.
 
         Returns:
-            _type_: _description_
+            dict[str, list[float | None]]: Group -> list of values for this metric.
         """
         self._assertmetric(metricname)
         return {g: self.get(g, metricname) for g in self.__groupnames}
@@ -366,10 +370,10 @@ class Panoptica_Statistic:
         """Gets the dictionary mapping metric to values for ONE group
 
         Args:
-            groupname (str): _description_
+            groupname (str): Name of the group to extract.
 
         Returns:
-            _type_: _description_
+            dict[str, list[float | None]]: Metric -> list of values for this group.
         """
         self._assertgroup(groupname)
         return {m: self.get(groupname, m) for m in self.__metricnames}
@@ -378,7 +382,7 @@ class Panoptica_Statistic:
         """Converts the statistic to a pandas dataframe
 
         Returns:
-            pd.DataFrame: _description_
+            pd.DataFrame: One row per (subject, group), with a column per metric.
         """
         data = []
         for subj in self.__subj_names:
@@ -395,10 +399,10 @@ class Panoptica_Statistic:
         """Given metric, gives list of all values (even across groups!) Treat with care!
 
         Args:
-            metric (_type_): _description_
+            metric (str): Name of the metric to pool.
 
         Returns:
-            _type_: _description_
+            list[float | None]: All values of the metric concatenated across every group.
         """
         values = []
         for g in self.__groupnames:
@@ -407,13 +411,13 @@ class Panoptica_Statistic:
 
     def get_subject_wise_paired_values_to(
         self, other: "Panoptica_Statistic", group: str, metric: str
-    ) -> tuple[list[str], list[float], list[float]]:
+    ) -> tuple[list[str], list[float | None], list[float | None]]:
         """Calculates the subject-wise paired values in metric for given group to another Panoptica_Statistic object
 
         Args:
-            other (Panoptica_Statistic): _description_
-            group (str): _description_
-            metric (str): _description_
+            other (Panoptica_Statistic): The other statistic to compare against (must share subject names).
+            group (str): Group to compare.
+            metric (str): Metric to compare.
         """
         self._assertgroup(group)
         self._assertmetric(metric)
@@ -451,16 +455,16 @@ class Panoptica_Statistic:
         """Calculates the subject-wise difference in metric for given group to another Panoptica_Statistic object
 
         Args:
-            other (Panoptica_Statistic): _description_
-            group (str): _description_
-            metric (str): _description_
+            other (Panoptica_Statistic): The other statistic to compare against (must share subject names).
+            group (str): Group to compare.
+            metric (str): Metric to compare.
         Returns:
-            dict[str, float]: _description_
+            dict[str, float | None]: Subject -> (self value minus other value); None where either is missing.
         """
         subj_names, self_v, other_v = self.get_subject_wise_paired_values_to(
             other, group, metric
         )
-        diff_dict = {}
+        diff_dict: dict[str, float | None] = {}
         for subj, val_self, val_other in zip(subj_names, self_v, other_v):
             if val_self is not None and val_other is not None:
                 diff_dict[subj] = val_self - val_other
@@ -472,7 +476,7 @@ class Panoptica_Statistic:
         """Calculates the average and std over all groups (so group-wise avg first, then average over those)
 
         Returns:
-            dict[str, tuple[float, float]]: _description_
+            dict[str, FloatDistribution]: Metric -> distribution of the per-group averages.
         """
         summary_dict = {}
         for m in self.__metricnames:
@@ -608,7 +612,7 @@ def make_autc_plots(
         thresholds = stat.get_thresholds_for_metric(metric)
 
         if not thresholds:
-            print(f"Warning: No threshold data found for '{metric}' in '{setupname}'.")
+            logger.warning(f"No threshold data found for '{metric}' in '{setupname}'.")
             continue
 
         X = thresholds
@@ -716,7 +720,7 @@ def make_curve_over_setups(
 
     # If X (setupnames) are digits only, plot as digits
     if convert_x_to_digit:
-        X = [float(s) for s in setupnames]
+        X: list = [float(s) for s in setupnames]
     else:
         X = setupnames
 

--- a/panoptica/utils/config.py
+++ b/panoptica/utils/config.py
@@ -1,10 +1,10 @@
 from ruamel.yaml import YAML
+from panoptica.utils.logger import logger
 from pathlib import Path
 from panoptica.utils.filepath import config_by_name, config_dir_by_name
-from abc import ABC, abstractmethod
-from warnings import warn
+from abc import abstractmethod
 
-supported_helper_classes = []
+supported_helper_classes: list[type] = []
 
 
 def _register_helper_classes(yaml: YAML):
@@ -71,7 +71,7 @@ def _save_yaml(data_dict: dict | object, out_file: str | Path, registered_class=
         #    yaml.dump([registered_class(*data_dict)], out_file)
     else:
         yaml.dump(data_dict, out_file)
-    print(f"Saved config into {out_file}")
+    logger.info(f"Saved config into {out_file}")
 
 
 #########

--- a/panoptica/utils/file_backend_jsonl.py
+++ b/panoptica/utils/file_backend_jsonl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from panoptica.utils.logger import logger
 
 from panoptica.utils.serialization import (
     format_instance_subject_name,
@@ -64,7 +65,7 @@ class JSONLBackend(FileBackend):
                         existing.append(format_instance_subject_name(sn, g, inst_idx))
 
         if not seen_any:
-            print(
+            logger.info(
                 f"{self.path}: Output file given is empty, will start with first subject"
             )
         return existing
@@ -97,7 +98,7 @@ class JSONLBackend(FileBackend):
     def append_subject(
         self,
         subject_name: str,
-        result_grouped: dict[str, "PanopticaResult | PanopticaAUTCResult"],
+        result_grouped: dict[str, PanopticaResult | PanopticaAUTCResult],
         class_group_names: list[str],
         evaluation_metrics: list[str],
         output_individual_instance_metrics: bool,
@@ -108,7 +109,9 @@ class JSONLBackend(FileBackend):
             group_obj: dict = {}
             if output_individual_instance_metrics:
                 summary_dict = result.to_dict(True)
-                instance_dicts = summary_dict.pop("reference_instances", [])
+                instance_dicts: list = summary_dict.pop(  # type: ignore[assignment]
+                    "reference_instances", []
+                )
             else:
                 summary_dict = result.to_dict(False)
                 instance_dicts = []
@@ -135,7 +138,7 @@ class JSONLBackend(FileBackend):
             record["groups"][groupname] = group_obj
 
         _append_jsonl_record(self.path, record)
-        print(f"Saved entry {subject_name} into {self.path}")
+        logger.info(f"Saved entry {subject_name} into {self.path}")
 
     def write_full(
         self,
@@ -207,9 +210,9 @@ class JSONLBackend(FileBackend):
                     metric_names.append(k)
 
         if verbose:
-            print(f"Found {len(records)} entries")
-            print(f"Found metrics: {metric_names}")
-            print(f"Found groups: {group_names}")
+            logger.info(f"Found {len(records)} entries")
+            logger.info(f"Found metrics: {metric_names}")
+            logger.info(f"Found groups: {group_names}")
 
         subj_names: list[str] = []
         value_dict: dict[str, dict[str, list[float | None]]] = {
@@ -305,8 +308,7 @@ def _parse_jsonl_value(v) -> float | None:
             return None
         return f
     raise ValueError(
-        f"unsupported value {v!r} of type {type(v).__name__}; "
-        f"expected number or null"
+        f"unsupported value {v!r} of type {type(v).__name__}; expected number or null"
     )
 
 
@@ -318,7 +320,7 @@ def _iter_jsonl_records(path: Path):
     malformed line, so a partial write from a crash or a hand-edit gets
     pinpointed rather than surfacing as a context-free ``JSONDecodeError``.
     """
-    with open(path, "r", encoding="utf8") as f:
+    with open(path, encoding="utf8") as f:
         for line_number, line in enumerate(f, start=1):
             stripped = line.strip()
             if not stripped:

--- a/panoptica/utils/file_backend_tsv.py
+++ b/panoptica/utils/file_backend_tsv.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from panoptica.utils.logger import logger
 
 from panoptica.panoptica_result import PanopticaAUTCResult, PanopticaResult
 from panoptica.utils.file_backend import FileBackend
@@ -37,7 +38,7 @@ class TSVBackend(FileBackend):
         else:
             existing_header = _read_first_tsv_row(self.path)
             if len(existing_header) == 0:
-                print(
+                logger.info(
                     f"{self.path}: Output file given is empty, will start with header"
                 )
                 _append_tsv_rows(self.path, [header])
@@ -72,7 +73,7 @@ class TSVBackend(FileBackend):
                 summary_dict = result.to_dict(True)
                 # Row keys live under "reference_instances"; pop so they don't
                 # bleed into the summary loop below.
-                group_instance_rows[groupname] = summary_dict.pop(
+                group_instance_rows[groupname] = summary_dict.pop(  # type: ignore[assignment]
                     "reference_instances", []
                 )
                 if result.computation_time is not None:
@@ -111,7 +112,7 @@ class TSVBackend(FileBackend):
                     content.append(_canonical_tsv_value(result_dict.get(e)))
             _append_tsv_rows(self.path, [content])
 
-        print(f"Saved entry {subject_name} into {self.path}")
+        logger.info(f"Saved entry {subject_name} into {self.path}")
 
     def write_full(
         self,
@@ -141,7 +142,7 @@ class TSVBackend(FileBackend):
     def load_raw(
         self, verbose: bool = True
     ) -> tuple[list[str], dict[str, dict[str, list[float | None]]]]:
-        with open(self.path, "r", encoding="utf8", newline="") as tsvfile:
+        with open(self.path, encoding="utf8", newline="") as tsvfile:
             rd = csv.reader(tsvfile, delimiter="\t", lineterminator="\n")
             rows = list(rd)
 
@@ -154,8 +155,8 @@ class TSVBackend(FileBackend):
                 "First column is not subject_names, something wrong with the file?"
             )
 
-        keys_in_order: list[tuple[str, str]] = [
-            tuple(c.split("-", maxsplit=1)) for c in header[1:]  # type: ignore[misc]
+        keys_in_order: list[tuple[str, ...]] = [
+            tuple(c.split("-", maxsplit=1)) for c in header[1:]
         ]
         keys_in_order = [
             k if len(k) == 2 else ("ungrouped", k[0]) for k in keys_in_order
@@ -168,7 +169,7 @@ class TSVBackend(FileBackend):
         group_names = list(dict.fromkeys(k[0] for k in keys_in_order))
 
         if verbose:
-            print(f"Found {len(rows) - 1} entries")
+            logger.info(f"Found {len(rows) - 1} entries")
             print(f"Found metrics: {metric_names}")
             print(f"Found groups: {group_names}")
 
@@ -230,7 +231,7 @@ def _canonical_tsv_value(v):
 
 def _read_first_tsv_row(path: Path) -> list[str]:
     """Reads the first row of a TSV file. NOT THREAD SAFE BY ITSELF."""
-    with open(path, "r", encoding="utf8", newline="") as tsvfile:
+    with open(path, encoding="utf8", newline="") as tsvfile:
         rd = csv.reader(tsvfile, delimiter="\t", lineterminator="\n")
         return next(rd, [])
 
@@ -243,7 +244,7 @@ def _load_first_tsv_column(path: Path) -> list[str]:
     Raises:
         ValueError: If the file contains duplicate entries.
     """
-    with open(path, "r", encoding="utf8", newline="") as tsvfile:
+    with open(path, encoding="utf8", newline="") as tsvfile:
         rd = csv.reader(tsvfile, delimiter="\t", lineterminator="\n")
         rows = list(rd)
     id_list = [row[0] for row in rows]

--- a/panoptica/utils/input_check_and_conversion/check_nrrd_image.py
+++ b/panoptica/utils/input_check_and_conversion/check_nrrd_image.py
@@ -1,4 +1,5 @@
 import numpy as np
+from panoptica.utils.logger import logger
 from importlib.util import find_spec
 from pathlib import Path
 from panoptica.utils.input_check_and_conversion.input_data_type_checker import (
@@ -24,7 +25,7 @@ class NRRDImage:
             self.__space_origin: np.ndarray = np.array(header["space origin"])
             ndim: int = header["dimension"]
         except KeyError as e:
-            raise KeyError(f"Missing key in header: {e}")
+            raise KeyError(f"Missing key in header: {e}") from e
 
         if self.__space_directions.shape != (ndim, ndim):
             raise ValueError(
@@ -82,7 +83,7 @@ class NRRDImageChecker(_InputDataTypeChecker):
         try:
             readdata, header = nrrd.read(str(image_path))
         except Exception as e:
-            print(f"Error reading images: {e}")
+            logger.error(f"Error reading images: {e}")
             return None
         return NRRDImage(readdata, header)
 
@@ -98,16 +99,18 @@ class NRRDImageChecker(_InputDataTypeChecker):
         # start necessary comparisons
         # dimensions need to be exact
         if prediction_image.shape != reference_image.shape:
-            return False, "Dimension Mismatch: {} vs {}".format(
-                prediction_image.shape, reference_image.shape
+            return (
+                False,
+                f"Dimension Mismatch: {prediction_image.shape} vs {reference_image.shape}",
             )
 
         # check if the affine matrices are similar
         if (
             np.array(prediction_image.affine) - np.array(reference_image.affine)
         ).sum() > self.threshold:
-            return False, "Affine Mismatch: {} vs {}".format(
-                prediction_image.affine, reference_image.affine
+            return (
+                False,
+                f"Affine Mismatch: {prediction_image.affine} vs {reference_image.affine}",
             )
 
         return True, ""

--- a/panoptica/utils/input_check_and_conversion/check_torch_image.py
+++ b/panoptica/utils/input_check_and_conversion/check_torch_image.py
@@ -1,4 +1,5 @@
 import numpy as np
+from panoptica.utils.logger import logger
 from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
@@ -14,7 +15,7 @@ _spec = find_spec("torch")
 if _spec is not None:
     import torch
 else:
-    torch = None
+    torch = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     import torch
@@ -31,7 +32,7 @@ class TorchImageChecker(_InputDataTypeChecker):
         )
 
     def load_image_from_path(
-        self, image_path: Union[str, Path]
+        self, image_path: str | Path
     ) -> Union["torch.Tensor", None]:
         try:
             image = torch.load(
@@ -40,7 +41,7 @@ class TorchImageChecker(_InputDataTypeChecker):
                 map_location="cpu",
             )
         except Exception as e:
-            print(f"Error reading images: {e}")
+            logger.error(f"Error reading images: {e}")
             return None
         return image
 

--- a/panoptica/utils/input_check_and_conversion/sanity_checker.py
+++ b/panoptica/utils/input_check_and_conversion/sanity_checker.py
@@ -1,4 +1,5 @@
 from typing import Any
+from panoptica.utils.logger import logger
 import numpy as np
 from pathlib import Path
 from warnings import warn
@@ -36,9 +37,9 @@ class INPUTDTYPE(_Enum_Compare):
 def print_available_package_to_input_handlers():
     for d in INPUTDTYPE:
         if d.value.are_requirements_fulfilled():
-            print(f"{d.name} is available for input handling.")
+            logger.info(f"{d.name} is available for input handling.")
         else:
-            print(
+            logger.info(
                 f"{d.name} is not available for input handling. Missing packages: {d.value.missing_packages}"
             )
 
@@ -97,7 +98,7 @@ def sanity_check_and_convert_to_array(
             elif not is_path:
                 try:
                     r, msg, (pred, ref) = checker(prediction, reference)
-                except TypeError as e:
+                except TypeError:
                     continue
                 if not r:
                     raise ValueError(

--- a/panoptica/utils/logger.py
+++ b/panoptica/utils/logger.py
@@ -1,0 +1,35 @@
+"""Central logger for panoptica.
+
+Library code emits progress, status and error messages through :data:`logger`
+rather than ``print``, so output is structured, level-filterable and can be
+silenced or redirected by downstream applications::
+
+    import logging
+    logging.getLogger("panoptica").setLevel(logging.WARNING)  # quiet
+    logging.getLogger("panoptica").setLevel(logging.DEBUG)    # verbose
+
+A :class:`rich.logging.RichHandler` is attached once so that, like the previous
+``print`` calls, messages are visible out of the box; downstream code may remove
+or replace it. This module imports nothing from ``panoptica`` and is therefore
+free of the package's import cycles.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rich.logging import RichHandler
+
+logger = logging.getLogger("panoptica")
+
+if not logger.handlers:
+    _handler = RichHandler(
+        show_time=False,
+        show_path=False,
+        markup=False,
+        rich_tracebacks=True,
+    )
+    _handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(_handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False

--- a/panoptica/utils/processing_pair.py
+++ b/panoptica/utils/processing_pair.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from panoptica.utils.logger import logger
 
 import numpy as np
 
@@ -35,21 +36,23 @@ class _ProcessingPair(ABC):
             reference_arr (np.ndarray): Numpy array of reference labels.
             dtype (type | None): The expected datatype of arrays. If None, no datatype check is performed.
         """
-        self.__prediction_arr: np.ndarray = prediction_arr
-        self.__reference_arr: np.ndarray = reference_arr
+        self._prediction_arr: np.ndarray = prediction_arr
+        self._reference_arr: np.ndarray = reference_arr
         _check_array_integrity(
-            self.__prediction_arr, self.__reference_arr, dtype=int_type
+            self._prediction_arr, self._reference_arr, dtype=int_type
         )
         max_value = max(prediction_arr.max(), reference_arr.max())
         dtype = _get_smallest_fitting_uint(max_value)
         self.set_dtype(dtype)
-        self.__dtype = dtype
-        self.__n_dim: int = reference_arr.ndim
-        self.__ref_labels: tuple[int, ...] = tuple(_unique_without_zeros(reference_arr))  # type: ignore
-        self.__pred_labels: tuple[int, ...] = tuple(_unique_without_zeros(prediction_arr))  # type: ignore
-        self.__crop: tuple[slice, ...] = None
-        self.__is_cropped: bool = False
-        self.__uncropped_shape: tuple[int, ...] = reference_arr.shape
+        self._dtype = dtype
+        self._n_dim: int = reference_arr.ndim
+        self._ref_labels: tuple[int, ...] = tuple(_unique_without_zeros(reference_arr))
+        self._pred_labels: tuple[int, ...] = tuple(
+            _unique_without_zeros(prediction_arr)
+        )
+        self._crop: tuple[slice, ...] | None = None
+        self._is_cropped: bool = False
+        self._uncropped_shape: tuple[int, ...] = reference_arr.shape
 
     def crop_data(self, verbose: bool = False):
         """Crops prediction and reference arrays to non-zero regions.
@@ -57,25 +60,22 @@ class _ProcessingPair(ABC):
         Args:
             verbose (bool, optional): If True, prints cropping details. Defaults to False.
         """
-        if self.__is_cropped:
+        if self._is_cropped:
             return
-        if self.__crop is None:
-            self.__uncropped_shape = self.__prediction_arr.shape
-            self.__crop = _get_paired_crop(
-                self.__prediction_arr,
-                self.__reference_arr,
+        if self._crop is None:
+            self._uncropped_shape = self._prediction_arr.shape
+            self._crop = _get_paired_crop(
+                self._prediction_arr,
+                self._reference_arr,
             )
 
-        self.__prediction_arr = self.__prediction_arr[self.__crop]
-        self.__reference_arr = self.__reference_arr[self.__crop]
-        (
-            print(
-                f"-- Cropped from {self.__uncropped_shape} to {self.__prediction_arr.shape}"
+        self._prediction_arr = self._prediction_arr[self._crop]
+        self._reference_arr = self._reference_arr[self._crop]
+        if verbose:
+            logger.info(
+                f"-- Cropped from {self._uncropped_shape} to {self._prediction_arr.shape}"
             )
-            if verbose
-            else None
-        )
-        self.__is_cropped = True
+        self._is_cropped = True
 
     def uncrop_data(self, verbose: bool = False):
         """Restores the arrays to their original, uncropped shape.
@@ -83,25 +83,22 @@ class _ProcessingPair(ABC):
         Args:
             verbose (bool, optional): If True, prints uncropping details. Defaults to False.
         """
-        if not self.__is_cropped:
+        if not self._is_cropped:
             return
-        if self.__uncropped_shape is None:
+        if self._uncropped_shape is None:
             raise RuntimeError("Calling uncrop_data() without having cropped first")
-        prediction_arr = np.zeros(self.__uncropped_shape)
-        prediction_arr[self.__crop] = self.__prediction_arr
-        self.__prediction_arr = prediction_arr
+        prediction_arr = np.zeros(self._uncropped_shape)
+        prediction_arr[self._crop] = self._prediction_arr
+        self._prediction_arr = prediction_arr
 
-        reference_arr = np.zeros(self.__uncropped_shape)
-        reference_arr[self.__crop] = self.__reference_arr
-        (
-            print(
-                f"-- Uncropped from {self.__reference_arr.shape} to {self.__uncropped_shape}"
+        reference_arr = np.zeros(self._uncropped_shape)
+        reference_arr[self._crop] = self._reference_arr
+        if verbose:
+            logger.info(
+                f"-- Uncropped from {self._reference_arr.shape} to {self._uncropped_shape}"
             )
-            if verbose
-            else None
-        )
-        self.__reference_arr = reference_arr
-        self.__is_cropped = False
+        self._reference_arr = reference_arr
+        self._is_cropped = False
 
     def set_dtype(self, type):
         """Sets the data type for both prediction and reference arrays.
@@ -113,28 +110,28 @@ class _ProcessingPair(ABC):
             raise TypeError(
                 "set_dtype: tried to set dtype to something other than integers"
             )
-        self.__prediction_arr = self.__prediction_arr.astype(type)
-        self.__reference_arr = self.__reference_arr.astype(type)
+        self._prediction_arr = self._prediction_arr.astype(type)
+        self._reference_arr = self._reference_arr.astype(type)
 
     @property
     def prediction_arr(self):
-        return self.__prediction_arr
+        return self._prediction_arr
 
     @property
     def reference_arr(self):
-        return self.__reference_arr
+        return self._reference_arr
 
     @property
     def pred_labels(self):
-        return self.__pred_labels
+        return self._pred_labels
 
     @property
     def ref_labels(self):
-        return self.__ref_labels
+        return self._ref_labels
 
     @property
     def n_dim(self):
-        return self.__n_dim
+        return self._n_dim
 
     @property
     def _original_n_preds(self) -> int:
@@ -169,9 +166,9 @@ class _ProcessingPair(ABC):
         Creates an exact copy of this object
         """
         return type(self)(
-            prediction_arr=self.__prediction_arr.copy(),
-            reference_arr=self.__reference_arr.copy(),
-        )  # type: ignore
+            prediction_arr=self._prediction_arr.copy(),
+            reference_arr=self._reference_arr.copy(),
+        )
 
 
 class _ProcessingPairInstanced(_ProcessingPair):
@@ -231,7 +228,7 @@ class _ProcessingPairInstanced(_ProcessingPair):
             reference_arr=self.reference_arr.copy(),
             n_pred_instances=self.n_pred_instances,
             n_ref_instances=self.n_ref_instances,
-        )  # type: ignore
+        )
 
 
 def _check_array_integrity(
@@ -308,7 +305,7 @@ class UnmatchedInstancePair(_ProcessingPairInstanced):
             reference_arr,
             n_pred_instances,
             n_ref_instances,
-        )  # type: ignore
+        )
 
 
 class MatchedInstancePair(_ProcessingPairInstanced):
@@ -355,7 +352,7 @@ class MatchedInstancePair(_ProcessingPairInstanced):
             reference_arr,
             n_pred_instances,
             n_ref_instances,
-        )  # type: ignore
+        )
         if matched_instances is None:
             matched_instances = [i for i in self.pred_labels if i in self.ref_labels]
         self.matched_instances = matched_instances

--- a/panoptica/utils/timing.py
+++ b/panoptica/utils/timing.py
@@ -1,4 +1,5 @@
 import time
+from panoptica.utils.logger import logger
 
 
 def measure_time(func):
@@ -9,8 +10,8 @@ def measure_time(func):
         result = func(*args, **kwargs)
         end_time = time.time()
         elapsed_time = end_time - start_time
-        if hasattr(kwargs, "verbose") and getattr(kwargs, "verbose"):
-            print(f"-- {func.__name__} took {elapsed_time} seconds to execute.")
+        if hasattr(kwargs, "verbose") and kwargs.verbose:
+            logger.info(f"-- {func.__name__} took {elapsed_time} seconds to execute.")
         return result
 
     return wrapper


### PR DESCRIPTION
---
**Stacked PRs** (review / merge bottom-up):

1. #269 Fix AUTC integration on NumPy < 2.0 ✅ merged
2. #273 Speed up matching, surface metrics, Voronoi, and per-instance evaluation
3. #270 Add a logger and refactor the I/O and pipeline modules ← **this PR**
4. #271 Finish the refactor: remaining cleanup, type hints, and docstrings
5. #272 Add dev tooling: ruff, mypy, pre-commit, CI gate, and benchmark
---

Add `panoptica.utils.logger` (rich-backed, no panoptica imports) and route diagnostic/status/error `print()`s through it. The pipeline, result, statistics, aggregator, file backends, config, processing_pair and the nibabel/torch checkers reach their final refactored state here (logger calls, None-sentinel defaults, `_ProcessingPair` de-mangling, type hints). Behaviour unchanged; suite green.