### PR TITLE
Finish the refactor: remaining cleanup, type hints, and docstrings

### DIFF
--- a/panoptica/cli.py
+++ b/panoptica/cli.py
@@ -1,9 +1,7 @@
 import os
-from typing import Optional
 import typer
-from typing_extensions import Annotated
+from typing import Annotated
 from importlib.metadata import version
-import SimpleITK as sitk
 from pathlib import Path
 from warnings import warn
 
@@ -41,7 +39,7 @@ def main(
         ),
     ],
     config: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "-c",
             "--config",
@@ -49,7 +47,7 @@ def main(
         ),
     ],
     version: Annotated[
-        Optional[bool],
+        bool | None,
         typer.Option(
             "-v",
             "--version",

--- a/panoptica/instance_approximator.py
+++ b/panoptica/instance_approximator.py
@@ -1,4 +1,6 @@
-from abc import ABC, abstractmethod, ABCMeta
+"""Approximate instances from semantic segmentations via connected components."""
+
+from abc import abstractmethod, ABCMeta
 
 import numpy as np
 
@@ -65,6 +67,7 @@ class InstanceApproximator(SupportsConfig, metaclass=ABCMeta):
         """
         pass
 
+    @classmethod
     def _yaml_repr(cls, node) -> dict:
         raise NotImplementedError(
             f"Tried to get yaml representation of abstract class {cls.__name__}"
@@ -104,6 +107,7 @@ class InstanceApproximator(SupportsConfig, metaclass=ABCMeta):
             )
 
         # If label_group is LabelPartGroup, force OneHotConnectedComponentsInstanceApproximator
+        instance_pair: UnmatchedInstancePair | MatchedInstancePair
         if isinstance(label_group, LabelPartGroup):
             instance_pair = OneHotConnectedComponentsInstanceApproximator(
                 cca_backend=CCABackend.cc3d
@@ -145,7 +149,7 @@ class ConnectedComponentsInstanceApproximator(InstanceApproximator):
         """
         self.cca_backend = cca_backend
 
-    def _approximate_instances(
+    def _approximate_instances(  # type: ignore[override]
         self, semantic_pair: SemanticPair, **kwargs
     ) -> UnmatchedInstancePair:
         """
@@ -199,7 +203,7 @@ class OneHotConnectedComponentsInstanceApproximator(InstanceApproximator):
         # Move the class axis to the front: (C, *arr_shape)
         return np.moveaxis(one_hot, -1, 0)
 
-    def _approximate_instances(
+    def _approximate_instances(  # type: ignore[override]
         self, semantic_pair: SemanticPair, label_group: LabelGroup | None = None
     ) -> UnmatchedInstancePair:
         cca_backend = self.cca_backend

--- a/panoptica/instance_matcher.py
+++ b/panoptica/instance_matcher.py
@@ -1,6 +1,7 @@
+"""Algorithms for matching predicted instances to reference instances."""
+
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Tuple, List
 
 import numpy as np
 
@@ -23,9 +24,9 @@ from panoptica.utils.label_group import LabelGroup, LabelPartGroup
 class MatchingContext:
     """Encapsulates context information needed for matching operations."""
 
-    label_group: Optional[LabelGroup] = None
-    n_ref_labels: Optional[int] = None
-    processing_pair_orig_shape: Optional[Tuple] = None
+    label_group: LabelGroup | None = None
+    n_ref_labels: int | None = None
+    processing_pair_orig_shape: tuple | None = None
 
     @property
     def is_part_group(self) -> bool:
@@ -59,7 +60,7 @@ class InstanceMatchingAlgorithm(SupportsConfig, metaclass=ABCMeta):
     def _match_instances(
         self,
         unmatched_instance_pair: UnmatchedInstancePair,
-        context: Optional[MatchingContext] = None,
+        context: MatchingContext | None = None,
         **kwargs,
     ) -> InstanceLabelMap:
         """
@@ -120,9 +121,9 @@ class InstanceMatchingAlgorithm(SupportsConfig, metaclass=ABCMeta):
     def _calculate_matching_metric_pairs(
         self,
         unmatched_instance_pair: UnmatchedInstancePair,
-        context: Optional[MatchingContext],
+        context: MatchingContext | None,
         matching_metric: Metric,
-    ) -> List[Tuple[float, Tuple[int, int]]]:
+    ) -> list[tuple[float, tuple[int, int]]]:
         """
         Calculate matching metric pairs based on context.
 
@@ -141,6 +142,10 @@ class InstanceMatchingAlgorithm(SupportsConfig, metaclass=ABCMeta):
         ref_labels = unmatched_instance_pair.ref_labels
 
         if context is not None and context.is_part_group:
+            assert (
+                context.processing_pair_orig_shape is not None
+                and context.n_ref_labels is not None
+            )
             return _calc_matching_metric_of_overlapping_partlabels(
                 pred_arr,
                 ref_arr,
@@ -153,6 +158,7 @@ class InstanceMatchingAlgorithm(SupportsConfig, metaclass=ABCMeta):
                 pred_arr, ref_arr, ref_labels, matching_metric=matching_metric
             )
 
+    @classmethod
     def _yaml_repr(cls, node) -> dict:
         raise NotImplementedError(
             f"Tried to get yaml representation of abstract class {cls.__name__}"
@@ -217,10 +223,10 @@ class ThresholdBasedMatching(InstanceMatchingAlgorithm):
         }
 
     @abstractmethod
-    def _match_instances(
+    def _match_instances(  # type: ignore[override]
         self,
         unmatched_instance_pair: UnmatchedInstancePair,
-        context: Optional[MatchingContext] = None,
+        context: MatchingContext | None = None,
         *,
         matching_threshold: float,
         **kwargs,
@@ -246,7 +252,7 @@ class ThresholdBasedMatching(InstanceMatchingAlgorithm):
         n_ref_labels=None,
         processing_pair_orig_shape=None,
         *,
-        matching_threshold: Optional[float] = None,
+        matching_threshold: float | None = None,
         **kwargs,
     ) -> MatchedInstancePair:
         return super().match_instances(
@@ -290,10 +296,10 @@ class NaiveThresholdMatching(ThresholdBasedMatching):
         super().__init__(matching_metric, matching_threshold)
         self._allow_many_to_one = allow_many_to_one
 
-    def _match_instances(
+    def _match_instances(  # type: ignore[override]
         self,
         unmatched_instance_pair: UnmatchedInstancePair,
-        context: Optional[MatchingContext] = None,
+        context: MatchingContext | None = None,
         *,
         matching_threshold: float,
         **kwargs,
@@ -351,10 +357,10 @@ class MaxBipartiteMatching(ThresholdBasedMatching):
     This implementation maximizes the global matching score between predictions and references.
     """
 
-    def _match_instances(
+    def _match_instances(  # type: ignore[override]
         self,
         unmatched_instance_pair: UnmatchedInstancePair,
-        context: Optional[MatchingContext] = None,
+        context: MatchingContext | None = None,
         *,
         matching_threshold: float,
         **kwargs,
@@ -394,9 +400,9 @@ class MaxBipartiteMatching(ThresholdBasedMatching):
 
     def _create_cost_matrix(
         self,
-        ref_labels: List[int],
-        pred_labels: List[int],
-        mm_pairs: List[Tuple[float, Tuple[int, int]]],
+        ref_labels: list[int],
+        pred_labels: list[int],
+        mm_pairs: list[tuple[float, tuple[int, int]]],
         matching_threshold: float,
     ) -> np.ndarray:
         """Create cost matrix for bipartite matching."""
@@ -423,7 +429,7 @@ class MaxBipartiteMatching(ThresholdBasedMatching):
         return cost_matrix
 
     def _solve_bipartite_matching(
-        self, cost_matrix: np.ndarray, ref_labels: List[int], pred_labels: List[int]
+        self, cost_matrix: np.ndarray, ref_labels: list[int], pred_labels: list[int]
     ) -> InstanceLabelMap:
         """Solve the bipartite matching problem and return labelmap."""
         from scipy.optimize import linear_sum_assignment
@@ -456,10 +462,10 @@ class MaximizeMergeMatching(ThresholdBasedMatching):
         matching_threshold (float): The threshold for matching instances.
     """
 
-    def _match_instances(
+    def _match_instances(  # type: ignore[override]
         self,
         unmatched_instance_pair: UnmatchedInstancePair,
-        context: Optional[MatchingContext] = None,
+        context: MatchingContext | None = None,
         *,
         matching_threshold: float,
         **kwargs,

--- a/panoptica/panoptica_evaluator.py
+++ b/panoptica/panoptica_evaluator.py
@@ -1,3 +1,5 @@
+"""Top-level Panoptica_Evaluator orchestrating the approximation -> matching -> evaluation pipeline."""
+
 from panoptica.utils import format_autc_key
 from panoptica.utils import format_threshold_key
 from panoptica.panoptica_pipeline import _phase_instance_approximation
@@ -47,13 +49,8 @@ class Panoptica_Evaluator(SupportsConfig):
         instance_matcher: InstanceMatchingAlgorithm | None = None,
         edge_case_handler: EdgeCaseHandler | None = None,
         segmentation_class_groups: SegmentationClassGroups | None = None,
-        instance_metrics: list[Metric] = [
-            Metric.DSC,
-            Metric.IOU,
-            Metric.ASSD,
-            Metric.RVD,
-        ],
-        global_metrics: list[Metric] = [Metric.DSC],
+        instance_metrics: list[Metric] | None = None,
+        global_metrics: list[Metric] | None = None,
         decision_metric: Metric | None = None,
         decision_threshold: float | None = None,
         per_region_evaluation: bool = False,
@@ -85,6 +82,10 @@ class Panoptica_Evaluator(SupportsConfig):
         #
         self.__instance_approximator = instance_approximator
         self.__instance_matcher = instance_matcher
+        if instance_metrics is None:
+            instance_metrics = [Metric.DSC, Metric.IOU, Metric.ASSD, Metric.RVD]
+        if global_metrics is None:
+            global_metrics = [Metric.DSC]
         self.__eval_metrics = instance_metrics
         self.__global_metrics = global_metrics
         self.__decision_metric = decision_metric
@@ -276,7 +277,10 @@ class Panoptica_Evaluator(SupportsConfig):
             prediction_arr_grouped = label_group(processing_pair.prediction_arr)
             reference_arr_grouped = label_group(processing_pair.reference_arr)
 
-            processing_pair_grouped = processing_pair.__class__(prediction_arr=prediction_arr_grouped, reference_arr=reference_arr_grouped)  # type: ignore
+            processing_pair_grouped = processing_pair.__class__(
+                prediction_arr=prediction_arr_grouped,
+                reference_arr=reference_arr_grouped,
+            )
             instance_metadata = processing_pair_grouped.get_metadata()
             if label_group.single_instance and not isinstance(
                 processing_pair, MatchedInstancePair
@@ -300,7 +304,7 @@ class Panoptica_Evaluator(SupportsConfig):
             threshold_results: dict[float, PanopticaResult] = {}
             for threshold in thresholds:
                 threshold = float(threshold)
-                decision_threshold = threshold
+                decision_threshold: float | None = threshold
                 if label_group.single_instance:
                     decision_threshold = 0.0
                 elif decision_threshold_mode == "fixed":
@@ -351,7 +355,7 @@ class Panoptica_Evaluator(SupportsConfig):
             "sitk.Image",
         ],
         voxelspacing: tuple[float, ...] | None = None,
-    ) -> tuple[Union[MatchedInstancePair, UnmatchedInstancePair, SemanticPair], dict]:
+    ) -> tuple[MatchedInstancePair | UnmatchedInstancePair | SemanticPair, dict]:
         """Handles data ingestion, sanity checking, and initial validation."""
 
         # Sanity check input and convert to numpy arrays
@@ -491,7 +495,9 @@ class Panoptica_Evaluator(SupportsConfig):
         reference_arr_grouped = label_group(processing_pair.reference_arr)
 
         single_instance_mode = label_group.single_instance
-        processing_pair_grouped = processing_pair.__class__(prediction_arr=prediction_arr_grouped, reference_arr=reference_arr_grouped)  # type: ignore
+        processing_pair_grouped = processing_pair.__class__(
+            prediction_arr=prediction_arr_grouped, reference_arr=reference_arr_grouped
+        )
         if single_instance_mode and not isinstance(
             processing_pair, MatchedInstancePair
         ):

--- a/panoptica/utils/edge_case_handling.py
+++ b/panoptica/utils/edge_case_handling.py
@@ -103,23 +103,19 @@ class MetricZeroTPEdgeCaseHandling(SupportsConfig):
             )
 
         self._default_result = default_result
-        self._edgecase_dict: dict[EdgeCaseZeroTP, EdgeCaseResult] = {}
-        self._edgecase_dict[EdgeCaseZeroTP.EMPTY_PRED] = (
-            empty_prediction_result
-            if empty_prediction_result is not None
-            else default_result
-        )
-        self._edgecase_dict[EdgeCaseZeroTP.EMPTY_REF] = (
-            empty_reference_result
-            if empty_reference_result is not None
-            else default_result
-        )
-        self._edgecase_dict[EdgeCaseZeroTP.NO_INSTANCES] = (
-            no_instances_result if no_instances_result is not None else default_result
-        )
-        self._edgecase_dict[EdgeCaseZeroTP.NORMAL] = (
-            normal if normal is not None else default_result
-        )
+
+        # The validation above guarantees a non-None value for every key.
+        def _resolve(specific: EdgeCaseResult | None) -> EdgeCaseResult:
+            value = specific if specific is not None else default_result
+            assert value is not None
+            return value
+
+        self._edgecase_dict: dict[EdgeCaseZeroTP, EdgeCaseResult] = {
+            EdgeCaseZeroTP.EMPTY_PRED: _resolve(empty_prediction_result),
+            EdgeCaseZeroTP.EMPTY_REF: _resolve(empty_reference_result),
+            EdgeCaseZeroTP.NO_INSTANCES: _resolve(no_instances_result),
+            EdgeCaseZeroTP.NORMAL: _resolve(normal),
+        }
 
     def __call__(
         self, tp: int, n_pred_instances: int, n_ref_instances: int
@@ -182,33 +178,37 @@ class EdgeCaseHandler(SupportsConfig):
 
     def __init__(
         self,
-        listmetric_zeroTP_handling: dict[Metric, MetricZeroTPEdgeCaseHandling] = {
-            Metric.DSC: MetricZeroTPEdgeCaseHandling(
-                no_instances_result=EdgeCaseResult.NAN,
-                default_result=EdgeCaseResult.ZERO,
-            ),
-            Metric.clDSC: MetricZeroTPEdgeCaseHandling(
-                no_instances_result=EdgeCaseResult.NAN,
-                default_result=EdgeCaseResult.ZERO,
-            ),
-            Metric.IOU: MetricZeroTPEdgeCaseHandling(
-                no_instances_result=EdgeCaseResult.NAN,
-                empty_prediction_result=EdgeCaseResult.ZERO,
-                default_result=EdgeCaseResult.ZERO,
-            ),
-            Metric.ASSD: MetricZeroTPEdgeCaseHandling(
-                no_instances_result=EdgeCaseResult.NAN,
-                default_result=EdgeCaseResult.INF,
-            ),
-            Metric.RVD: MetricZeroTPEdgeCaseHandling(
-                default_result=EdgeCaseResult.NAN,
-            ),
-            Metric.RVAE: MetricZeroTPEdgeCaseHandling(
-                default_result=EdgeCaseResult.NAN,
-            ),
-        },
+        listmetric_zeroTP_handling: (
+            dict[Metric, MetricZeroTPEdgeCaseHandling] | None
+        ) = None,
         empty_list_std: EdgeCaseResult = EdgeCaseResult.NAN,
     ) -> None:
+        if listmetric_zeroTP_handling is None:
+            listmetric_zeroTP_handling = {
+                Metric.DSC: MetricZeroTPEdgeCaseHandling(
+                    no_instances_result=EdgeCaseResult.NAN,
+                    default_result=EdgeCaseResult.ZERO,
+                ),
+                Metric.clDSC: MetricZeroTPEdgeCaseHandling(
+                    no_instances_result=EdgeCaseResult.NAN,
+                    default_result=EdgeCaseResult.ZERO,
+                ),
+                Metric.IOU: MetricZeroTPEdgeCaseHandling(
+                    no_instances_result=EdgeCaseResult.NAN,
+                    empty_prediction_result=EdgeCaseResult.ZERO,
+                    default_result=EdgeCaseResult.ZERO,
+                ),
+                Metric.ASSD: MetricZeroTPEdgeCaseHandling(
+                    no_instances_result=EdgeCaseResult.NAN,
+                    default_result=EdgeCaseResult.INF,
+                ),
+                Metric.RVD: MetricZeroTPEdgeCaseHandling(
+                    default_result=EdgeCaseResult.NAN,
+                ),
+                Metric.RVAE: MetricZeroTPEdgeCaseHandling(
+                    default_result=EdgeCaseResult.NAN,
+                ),
+            }
         self.__listmetric_zeroTP_handling: dict[
             Metric, MetricZeroTPEdgeCaseHandling
         ] = listmetric_zeroTP_handling
@@ -221,16 +221,16 @@ class EdgeCaseHandler(SupportsConfig):
         n_pred_instances: int,
         n_ref_instances: int,
     ) -> tuple[bool, float | None]:
-        """_summary_
+        """Resolve the metric value when an instance pair has zero true positives.
 
         Args:
-            metric (Metric): _description_
-            tp (int): _description_
-            n_pred_instances (int): _description_
-            n_ref_instances (int): _description_
+            metric (Metric): The metric being evaluated.
+            tp (int): True-positive count; handling only applies when this is 0.
+            n_pred_instances (int): Number of prediction instances.
+            n_ref_instances (int): Number of reference instances.
 
         Raises:
-            NotImplementedError: _description_
+            NotImplementedError: If no zero-TP handling is configured for this metric.
 
         Returns:
             tuple[bool, float | None]: if edge case, and its edge case value
@@ -255,7 +255,7 @@ class EdgeCaseHandler(SupportsConfig):
     def get_metric_zero_tp_handle(self, metric: Metric):
         return self.__listmetric_zeroTP_handling[metric]
 
-    def handle_empty_list_std(self) -> EdgeCaseResult | None:
+    def handle_empty_list_std(self) -> EdgeCaseResult:
         return self.__empty_list_std
 
     def __str__(self) -> str:

--- a/panoptica/utils/input_check_and_conversion/check_nibabel_image.py
+++ b/panoptica/utils/input_check_and_conversion/check_nibabel_image.py
@@ -25,7 +25,7 @@ class NibabelImageChecker(_InputDataTypeChecker):
         except Exception as e:
             print(f"Error reading images: {e}")
             return None
-        return image
+        return image  # type: ignore[return-value]
 
     def sanity_check_images(
         self,
@@ -56,9 +56,7 @@ class NibabelImageChecker(_InputDataTypeChecker):
         if prediction_image.shape != reference_image.shape:
             return (
                 False,
-                "Dimension Mismatch: {} vs {}".format(
-                    prediction_image.shape, reference_image.shape
-                ),
+                f"Dimension Mismatch: {prediction_image.shape} vs {reference_image.shape}",
             )
 
         # check if the affine matrices are similar
@@ -67,15 +65,13 @@ class NibabelImageChecker(_InputDataTypeChecker):
         ).sum() > self.threshold:
             return (
                 False,
-                "Affine Mismatch: {} vs {}".format(
-                    prediction_image.affine, reference_image.affine
-                ),
+                f"Affine Mismatch: {prediction_image.affine} vs {reference_image.affine}",
             )
 
         return True, ""
 
     def convert_to_numpy_array(self, image: nib.Nifti1Image) -> np.ndarray:
-        return np.asanyarray(image.dataobj, dtype=image.dataobj.dtype).copy()
+        return np.asanyarray(image.dataobj, dtype=image.dataobj.dtype).copy()  # type: ignore[attr-defined]
 
     def extract_metadata_from_image(self, image: nib.Nifti1Image) -> dict:
         """

--- a/panoptica/utils/input_check_and_conversion/check_numpy_array.py
+++ b/panoptica/utils/input_check_and_conversion/check_numpy_array.py
@@ -45,8 +45,9 @@ def _sanity_check_images(
 
     # dimensions need to be exact
     if prediction_image.shape != reference_image.shape:
-        return False, "Dimension Mismatch: {} vs {}".format(
-            prediction_image.shape, reference_image.shape
+        return (
+            False,
+            f"Dimension Mismatch: {prediction_image.shape} vs {reference_image.shape}",
         )
 
     return True, ""

--- a/panoptica/utils/input_check_and_conversion/check_sitk_image.py
+++ b/panoptica/utils/input_check_and_conversion/check_sitk_image.py
@@ -65,14 +65,16 @@ class SITKImageChecker(_InputDataTypeChecker):
 
         # dimensions need to be exact
         if prediction_image.GetDimension() != reference_image.GetDimension():
-            return False, "Dimension Mismatch: {} vs {}".format(
-                prediction_image.GetDimension(), reference_image.GetDimension()
+            return (
+                False,
+                f"Dimension Mismatch: {prediction_image.GetDimension()} vs {reference_image.GetDimension()}",
             )
 
         # size need to be exact
         if prediction_image.GetSize() != reference_image.GetSize():
-            return False, "Size Mismatch: {} vs {}".format(
-                prediction_image.GetSize(), reference_image.GetSize()
+            return (
+                False,
+                f"Size Mismatch: {prediction_image.GetSize()} vs {reference_image.GetSize()}",
             )
 
         # origin, direction, and spacing need to be "similar" enough
@@ -81,24 +83,27 @@ class SITKImageChecker(_InputDataTypeChecker):
             np.array(prediction_image.GetOrigin())
             - np.array(reference_image.GetOrigin())
         ).sum() > self.threshold:
-            return False, "Origin Mismatch: {} vs {}".format(
-                prediction_image.GetOrigin(), reference_image.GetOrigin()
+            return (
+                False,
+                f"Origin Mismatch: {prediction_image.GetOrigin()} vs {reference_image.GetOrigin()}",
             )
 
         if (
             np.array(prediction_image.GetSpacing())
             - np.array(reference_image.GetSpacing())
         ).sum() > self.threshold:
-            return False, "Spacing Mismatch: {} vs {}".format(
-                prediction_image.GetSpacing(), reference_image.GetSpacing()
+            return (
+                False,
+                f"Spacing Mismatch: {prediction_image.GetSpacing()} vs {reference_image.GetSpacing()}",
             )
 
         if (
             np.array(prediction_image.GetDirection())
             - np.array(reference_image.GetDirection())
         ).sum() > self.threshold:
-            return False, "Direction Mismatch: {} vs {}".format(
-                prediction_image.GetDirection(), reference_image.GetDirection()
+            return (
+                False,
+                f"Direction Mismatch: {prediction_image.GetDirection()} vs {reference_image.GetDirection()}",
             )
 
         # check if the number of components is the same - this is needed for multi-channel or vector images
@@ -106,9 +111,9 @@ class SITKImageChecker(_InputDataTypeChecker):
             prediction_image.GetNumberOfComponentsPerPixel()
             != reference_image.GetNumberOfComponentsPerPixel()
         ):
-            return False, "Number of Components Mismatch: {} vs {}".format(
-                prediction_image.GetNumberOfComponentsPerPixel(),
-                reference_image.GetNumberOfComponentsPerPixel(),
+            return (
+                False,
+                f"Number of Components Mismatch: {prediction_image.GetNumberOfComponentsPerPixel()} vs {reference_image.GetNumberOfComponentsPerPixel()}",
             )
 
         return True, ""

--- a/panoptica/utils/input_check_and_conversion/input_data_type_checker.py
+++ b/panoptica/utils/input_check_and_conversion/input_data_type_checker.py
@@ -83,8 +83,8 @@ class _InputDataTypeChecker(ABC):
         """Tries to load the images of that data type and then checks if they are compatible.
 
         Args:
-            prediction (_type_): Prediction image or path to prediction image.
-            reference (_type_): Reference image or path to reference image.
+            prediction: Prediction image or path to prediction image.
+            reference: Reference image or path to reference image.
 
         Returns:
             tuple[bool, str, tuple[object, object]]: A tuple containing a boolean indicating success, an (error) message string, and a tuple of the loaded images.

--- a/panoptica/utils/instancelabelmap.py
+++ b/panoptica/utils/instancelabelmap.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 # Many-to-One Mapping
-class InstanceLabelMap(object):
+class InstanceLabelMap:
     """Creates a mapping between prediction labels and reference labels in a many-to-one relationship.
 
     This class allows mapping multiple prediction labels to a single reference label.

--- a/panoptica/utils/label_group.py
+++ b/panoptica/utils/label_group.py
@@ -283,7 +283,7 @@ class _LabelGroupAny(LabelGroup):
         return array
 
     def __str__(self) -> str:
-        return f"LabelGroupAny"
+        return "LabelGroupAny"
 
     def __repr__(self) -> str:
         return str(self)

--- a/panoptica/utils/numpy_utils.py
+++ b/panoptica/utils/numpy_utils.py
@@ -52,6 +52,7 @@ def _get_smallest_fitting_uint(max_value: int) -> type:
     >>> _get_smallest_fitting_uint(255)
     <class 'numpy.uint8'>
     """
+    dtype: type
     if max_value < 256:
         dtype = np.uint8
     elif max_value < 65536:
@@ -82,22 +83,21 @@ def _get_bbox_nd(
         raise ValueError("bbox_nd: img is empty, cannot calculate a bbox")
     N = img.ndim
     shp = img.shape
-    if isinstance(px_dist, int):
-        px_dist = np.ones(N, dtype=np.uint8) * px_dist
-    if len(px_dist) != N:
+    pad: list[int] = [px_dist] * N if isinstance(px_dist, int) else list(px_dist)
+    if len(pad) != N:
         raise ValueError(
             f"dimension mismatch, got img shape {shp} and px_dist {px_dist}"
         )
 
-    out = []
+    bounds: list[int] = []
     for ax in itertools.combinations(reversed(range(N)), N - 1):
         nonzero = np.any(a=img, axis=ax)
-        out.extend(np.where(nonzero)[0][[0, -1]])
-    out = tuple(
+        idx = np.where(nonzero)[0]
+        bounds.extend((int(idx[0]), int(idx[-1])))
+    return tuple(
         slice(
-            max(out[i] - px_dist[i // 2], 0),
-            min(out[i + 1] + px_dist[i // 2], shp[i // 2]) + 1,
+            max(bounds[i] - pad[i // 2], 0),
+            min(bounds[i + 1] + pad[i // 2], shp[i // 2]) + 1,
         )
-        for i in range(0, len(out), 2)
+        for i in range(0, len(bounds), 2)
     )
-    return out

--- a/panoptica/utils/parallel_processing.py
+++ b/panoptica/utils/parallel_processing.py
@@ -1,6 +1,6 @@
 import multiprocessing.pool
-from multiprocessing import Pool, Process
-from typing import Callable
+from multiprocessing import Process
+from collections.abc import Callable
 
 
 class NoDaemonProcess(Process):
@@ -52,4 +52,4 @@ class NonDaemonicPool(multiprocessing.pool.Pool):
     This class creates a pool of worker processes using `NoDaemonProcess` for situations where nested child processes are needed.
     """
 
-    Process = NoDaemonProcess
+    Process = NoDaemonProcess  # type: ignore[assignment]

--- a/panoptica/utils/segmentation_class.py
+++ b/panoptica/utils/segmentation_class.py
@@ -1,5 +1,4 @@
 import numpy as np
-from pathlib import Path
 from panoptica.utils.config import SupportsConfig
 from panoptica.utils.label_group import LabelGroup, _LabelGroupAny
 from panoptica.utils.serialization import validate_group_name


### PR DESCRIPTION
---
**Stacked PRs** (review / merge bottom-up):

1. #269 Fix AUTC integration on NumPy < 2.0 ✅ merged
2. #273 Speed up matching, surface metrics, Voronoi, and per-instance evaluation
3. #270 Add a logger and refactor the I/O and pipeline modules
4. #271 Finish the refactor: remaining cleanup, type hints, and docstrings ← **this PR**
5. #272 Add dev tooling: ruff, mypy, pre-commit, CI gate, and benchmark
---

None-sentinel defaults in `Panoptica_Evaluator`/`EdgeCaseHandler`; removed dead code (`DirectValueMeta`); accurate docstrings replacing the autogenerated stubs + module docstrings; type annotations/asserts so the package is mypy-clean. Behaviour unchanged; suite green.