### PR TITLE
Speed up matching, surface metrics, Voronoi, and per-instance evaluation

### DIFF
--- a/panoptica/_functionals.py
+++ b/panoptica/_functionals.py
@@ -1,11 +1,14 @@
-from typing import TYPE_CHECKING
-from multiprocessing import Pool
-import numpy as np
+"""Low-level array helpers: connected components, label overlap/matching, cropping, Voronoi regions."""
+
 import math
-from panoptica.utils.constants import CCABackend
-from panoptica.utils.numpy_utils import _get_bbox_nd
+from typing import TYPE_CHECKING
+
+import numpy as np
 from scipy import ndimage
 from scipy.ndimage import distance_transform_edt
+
+from panoptica.utils.constants import CCABackend
+from panoptica.utils.numpy_utils import _get_bbox_nd
 
 if TYPE_CHECKING:
     from panoptica.metrics import Metric
@@ -79,7 +82,7 @@ def _get_paired_crop(
     prediction_arr: np.ndarray,
     reference_arr: np.ndarray,
     px_pad: int = 2,
-) -> np.ndarray:
+) -> tuple[slice, ...]:
     """
     Calculates a bounding box based on paired prediction and reference arrays.
 
@@ -172,6 +175,55 @@ def _calc_overlapping_labels(
     ]
 
 
+def _calc_count_matching_metric_of_overlapping_labels(
+    prediction_arr: np.ndarray,
+    reference_arr: np.ndarray,
+    ref_labels: tuple[int, ...],
+    matching_metric: "Metric",
+) -> list[tuple[float, tuple[int, int]]]:
+    """
+    Vectorized IoU / Dice for every overlapping (ref_label, pred_label) pair.
+
+    Both metrics are pure functions of the per-pair intersection count and the two
+    per-label areas. Encoding each voxel's (pred, ref) pair as ``pred * max_ref + ref``
+    turns ``np.unique(..., return_counts=True)`` into the full table of intersection
+    counts in a single pass, and ``np.bincount`` gives the per-label areas. This
+    replaces one full-array metric evaluation per overlapping pair (O(pairs * voxels))
+    with O(voxels + pairs), producing identical scores.
+
+    Args:
+        prediction_arr: Array containing prediction labels
+        reference_arr: Array containing reference labels
+        ref_labels: Unique reference labels
+        matching_metric: Either ``Metric.IOU`` or ``Metric.DSC``
+
+    Returns:
+        list: Unsorted list of (metric_value, (ref_label, pred_label)) pairs
+    """
+    max_ref = max(ref_labels) + 1
+    encoded = reference_arr.astype(np.int64) + prediction_arr.astype(np.int64) * max_ref
+    encoded[reference_arr == 0] = 0
+
+    values, intersections = np.unique(encoded, return_counts=True)
+    keep = values > max_ref  # both pred and ref are foreground for these
+    values = values[keep]
+    intersection = intersections[keep].astype(np.float64)
+    pair_ref = values % max_ref
+    pair_pred = values // max_ref
+
+    ref_area = np.bincount(reference_arr.ravel())[pair_ref].astype(np.float64)
+    pred_area = np.bincount(prediction_arr.ravel())[pair_pred].astype(np.float64)
+
+    if matching_metric.name == "IOU":
+        scores = intersection / (ref_area + pred_area - intersection)
+    else:  # DSC
+        scores = 2.0 * intersection / (ref_area + pred_area)
+
+    return [
+        (float(s), (int(r), int(p))) for s, r, p in zip(scores, pair_ref, pair_pred)
+    ]
+
+
 def _calc_matching_metric_of_overlapping_labels(
     prediction_arr: np.ndarray,
     reference_arr: np.ndarray,
@@ -190,16 +242,25 @@ def _calc_matching_metric_of_overlapping_labels(
     Returns:
         list: Sorted list of (metric_value, (ref_label, pred_label)) pairs
     """
-    overlapping_labels = _calc_overlapping_labels(
-        prediction_arr=prediction_arr,
-        reference_arr=reference_arr,
-        ref_labels=ref_labels,
-    )
-
-    mm_pairs = [
-        (matching_metric.value(reference_arr, prediction_arr, i[0], i[1]), (i[0], i[1]))
-        for i in overlapping_labels
-    ]
+    # IoU and Dice have a closed form over the overlap table and can score every pair
+    # at once; other (e.g. spatial) metrics still need a per-pair evaluation.
+    if matching_metric.name in ("IOU", "DSC"):
+        mm_pairs = _calc_count_matching_metric_of_overlapping_labels(
+            prediction_arr, reference_arr, ref_labels, matching_metric
+        )
+    else:
+        overlapping_labels = _calc_overlapping_labels(
+            prediction_arr=prediction_arr,
+            reference_arr=reference_arr,
+            ref_labels=ref_labels,
+        )
+        mm_pairs = [
+            (
+                matching_metric.value(reference_arr, prediction_arr, i[0], i[1]),
+                (i[0], i[1]),
+            )
+            for i in overlapping_labels
+        ]
 
     mm_pairs = sorted(
         mm_pairs, key=lambda x: x[0], reverse=not matching_metric.decreasing
@@ -223,7 +284,7 @@ def calculate_all_label_pairs(
         list: All (reference_label, prediction_label) pairs
     """
     pred_labels = [int(label) for label in np.unique(prediction_arr) if label > 0]
-    ref_labels = [int(label) for label in ref_labels if label > 0]
+    ref_labels = tuple(int(label) for label in ref_labels if label > 0)
 
     return [
         (ref_label, pred_label)
@@ -257,7 +318,7 @@ def _is_part_encompassed(part_component: np.ndarray, thing_mask: np.ndarray) -> 
     boundary = dilated_part & ~part_component
 
     # If all boundary pixels are thing pixels, the part is surrounded
-    return np.all((boundary & thing_mask) == boundary)
+    return bool(np.all((boundary & thing_mask) == boundary))
 
 
 def _get_encompassed_parts(part_slice: np.ndarray, thing_mask: np.ndarray) -> list[int]:
@@ -321,8 +382,7 @@ def _find_optimal_part_matching_per_type(
         return [0.0]  # Penalty for part type mismatch
 
     # Get unique parts
-    ref_parts = set(pair[1][0] for pair in part_pairs)
-    pred_parts = set(pair[1][1] for pair in part_pairs)
+    ref_parts = {pair[1][0] for pair in part_pairs}
 
     # Sort part pairs by score
     sorted_pairs = sorted(
@@ -462,7 +522,7 @@ def _calculate_combined_part_score(
 
     all_part_scores = []
 
-    for part_type, part_pairs in part_scores_by_type.items():
+    for _part_type, part_pairs in part_scores_by_type.items():
         # Get optimal matching for this part type
         matching_scores = _find_optimal_part_matching_per_type(
             part_pairs, matching_metric
@@ -513,7 +573,7 @@ def _calc_matching_metric_of_overlapping_partlabels(
     overlapping_labels = _calc_overlapping_labels(
         prediction_arr=prediction_arr[0],
         reference_arr=reference_arr[0],
-        ref_labels=[max(prediction_arr[0].max(), reference_arr[0].max())],
+        ref_labels=(int(max(prediction_arr[0].max(), reference_arr[0].max())),),
     )
 
     # Calculate thing scores
@@ -592,30 +652,31 @@ def _get_voronoi_regions(
     n_ref_instances: int,
 ) -> tuple[np.ndarray, int]:
     """
-    Get ground truth regions using connected components and distance transforms.
+    Assign every voxel to its nearest labelled reference region (a Voronoi partition).
 
     Args:
-        arr: Input array
-        n_ref_instances: Number of reference instances
+        arr: Labelled reference array (background ``0``, instances ``1..n``).
+        n_ref_instances: Number of reference instances.
 
     Returns:
-        Tuple of (region_map, n_ref_instances) where region_map assigns each pixel
-        to the closest ground truth region.
+        Tuple of ``(region_map, n_ref_instances)`` where ``region_map`` assigns each
+        voxel the label of the nearest reference region.
+
+    Notes:
+        Computed with a single Euclidean feature transform of the background
+        (``distance_transform_edt(arr == 0, return_indices=True)``), which yields, for
+        every voxel, the index of the nearest labelled voxel in one pass. This replaces
+        the previous per-region loop (one full-array distance transform per instance,
+        O(n_instances * n_voxels)) with an O(n_voxels) computation while producing the
+        same nearest-region assignment.
     """
-    # Step 2: Compute distance transform for each region
-    distance_map = np.full(arr.shape, np.inf, dtype=np.float32)
-    region_map = np.zeros(arr.shape, dtype=np.int32)
+    if n_ref_instances <= 0 or not arr.any():
+        return np.zeros(arr.shape, dtype=np.int32), n_ref_instances
 
-    for region_label in range(1, n_ref_instances + 1):
-        # Create region mask
-        region_mask = arr == region_label
-
-        # Compute distance transform
-        distance = distance_transform_edt(~region_mask)
-
-        # Update pixels where this region is closer
-        update_mask = distance < distance_map
-        distance_map[update_mask] = distance[update_mask]
-        region_map[update_mask] = region_label
-
+    # Feature transform of the complement: the "nearest background voxel" of (arr == 0)
+    # is precisely the nearest labelled voxel of ``arr``.
+    indices = distance_transform_edt(
+        arr == 0, return_distances=False, return_indices=True
+    )
+    region_map = arr[tuple(indices)].astype(np.int32)
     return region_map, n_ref_instances

--- a/panoptica/instance_evaluator.py
+++ b/panoptica/instance_evaluator.py
@@ -1,10 +1,68 @@
-from dataclasses import dataclass, field
-from multiprocessing import Pool
-import numpy as np
+"""Per-instance metric evaluation for matched instance pairs."""
 
+from dataclasses import dataclass, field
+
+import numpy as np
+from scipy.ndimage import find_objects
+
+from panoptica._functionals import _get_orig_onehotcc_structure, _get_paired_crop
 from panoptica.metrics import Metric
-from panoptica.utils.processing_pair import MatchedInstancePair, EvaluateInstancePair
-from panoptica._functionals import _get_paired_crop, _get_orig_onehotcc_structure
+from panoptica.metrics._surface_distances import (
+    SURFACE_DISTANCE_METRIC_NAMES,
+    _reduce_surface_metric,
+    _surface_distance_pair,
+)
+from panoptica.utils.processing_pair import EvaluateInstancePair, MatchedInstancePair
+
+
+def _extended_voxelspacing(voxelspacing: tuple[float, ...], ndim: int):
+    """Match a voxelspacing to a spatial array, padding non-spatial (label) axes.
+
+    Flattened one-hot arrays gain leading label axes when reshaped to
+    ``(num_labels + 1, *spatial_shape)``; spatial metrics need a spacing entry per
+    axis, so unit spacing is prepended for those extra dimensions.
+    """
+    if len(voxelspacing) < ndim:
+        extra_dims = ndim - len(voxelspacing)
+        return (1.0,) * extra_dims + tuple(voxelspacing)
+    if len(voxelspacing) > ndim:
+        raise ValueError(
+            f"Voxelspacing has {len(voxelspacing)} dimensions but the spatial array "
+            f"only has {ndim} dimensions. Voxelspacing should match the original "
+            f"spatial dimensions of the data."
+        )
+    return voxelspacing
+
+
+def _union_instance_slice(
+    ref_slices: list,
+    pred_slices: list,
+    label: int,
+    shape: tuple[int, ...],
+    px_pad: int = 2,
+) -> tuple[slice, ...] | None:
+    """Padded union of a label's reference and prediction bounding boxes.
+
+    ``ref_slices`` / ``pred_slices`` are ``scipy.ndimage.find_objects`` outputs (indexed
+    by ``label - 1``, ``None`` where the label is absent). Returns a per-axis slice tuple
+    that bounds the instance in both arrays plus ``px_pad`` voxels (so the downstream
+    ``_get_paired_crop`` reproduces exactly the crop it would compute on the full array),
+    or ``None`` when the label is absent from both.
+    """
+    boxes = []
+    for slices in (ref_slices, pred_slices):
+        box = slices[label - 1] if 0 < label <= len(slices) else None
+        if box is not None:
+            boxes.append(box)
+    if not boxes:
+        return None
+    return tuple(
+        slice(
+            max(min(b[ax].start for b in boxes) - px_pad, 0),
+            min(max(b[ax].stop for b in boxes) + px_pad, shape[ax]),
+        )
+        for ax in range(len(shape))
+    )
 
 
 @dataclass(frozen=True)
@@ -24,7 +82,7 @@ class _InstanceEvaluation:
 
 def evaluate_matched_instance(
     matched_instance_pair: MatchedInstancePair,
-    eval_metrics: list[Metric] = [Metric.DSC, Metric.IOU, Metric.ASSD],
+    eval_metrics: list[Metric] | None = None,
     decision_metric: Metric | None = Metric.IOU,
     decision_threshold: float | None = None,
     voxelspacing: tuple[float, ...] | None = None,
@@ -43,6 +101,8 @@ def evaluate_matched_instance(
         EvaluateInstancePair: Evaluated pair of instances
 
     """
+    if eval_metrics is None:
+        eval_metrics = [Metric.DSC, Metric.IOU, Metric.ASSD]
     if decision_metric is not None:
         if decision_metric.name not in [v.name for v in eval_metrics]:
             raise ValueError("decision metric not contained in eval_metrics")
@@ -57,6 +117,11 @@ def evaluate_matched_instance(
     )
     ref_matched_labels = matched_instance_pair.matched_instances
 
+    # Precompute every label's bounding box once (a single pass over each array) so each
+    # instance is evaluated within its own crop instead of rescanning the full array.
+    ref_slices = find_objects(reference_arr)
+    pred_slices = find_objects(prediction_arr)
+
     per_instance_results: list[_InstanceEvaluation] = [
         _evaluate_instance(
             reference_arr,
@@ -66,14 +131,12 @@ def evaluate_matched_instance(
             voxelspacing,
             processing_pair_orig_shape,
             n_ref_labels,
+            instance_slice=_union_instance_slice(
+                ref_slices, pred_slices, ref_idx, reference_arr.shape
+            ),
         )
         for ref_idx in ref_matched_labels
     ]
-    # instance_pairs = [(reference_arr, prediction_arr, ref_idx, eval_metrics) for ref_idx in ref_matched_labels]
-    # with Pool() as pool:
-    #    metric_dicts: list[_InstanceEvaluation] = pool.starmap(
-    #        _evaluate_instance, instance_pairs
-    #    )
 
     # TODO if instance matcher already gives matching metric, adapt here!
     tp = 0
@@ -142,6 +205,7 @@ def _evaluate_instance(
     voxelspacing: tuple[float, ...] | None = None,
     processing_pair_orig_shape: tuple[int, ...] | None = None,
     n_ref_labels: int | None = None,
+    instance_slice: tuple[slice, ...] | None = None,
 ) -> _InstanceEvaluation:
     """
     Evaluate a single instance.
@@ -157,8 +221,14 @@ def _evaluate_instance(
         If the reference label is absent from ``reference_arr`` (``voxel_count_ref == 0``), the result has empty metrics and zero count/volume.
         If the reference is present but the prediction has no voxels for this label, the result has empty metrics but still carries the reference's true voxel count and volume, so the caller can record the ref as unmatched with its actual size.
     """
-    ref_arr = reference_arr == ref_idx
-    pred_arr = prediction_arr == ref_idx
+    # Restrict the per-instance mask extraction to the instance's bounding box when one
+    # was precomputed; the one-hot spatial path below still reshapes the full arrays.
+    if instance_slice is not None:
+        ref_arr = reference_arr[instance_slice] == ref_idx
+        pred_arr = prediction_arr[instance_slice] == ref_idx
+    else:
+        ref_arr = reference_arr == ref_idx
+        pred_arr = prediction_arr == ref_idx
 
     # Detect if we have flattened one-hot arrays that need reshaping for spatial metrics
     is_flattened_onehot = (
@@ -170,6 +240,7 @@ def _evaluate_instance(
     # Set default voxelspacing based on original or current array dimensions
     if voxelspacing is None:
         if is_flattened_onehot:
+            assert processing_pair_orig_shape is not None
             voxelspacing = (1.0,) * len(processing_pair_orig_shape)
         else:
             voxelspacing = (1.0,) * reference_arr.ndim
@@ -195,57 +266,56 @@ def _evaluate_instance(
 
     result: dict[Metric, float] = {}
 
-    # Cache spatial structures if any metric requires them and is_flattened_onehot is True
+    # Resolve the mask view spatial metrics operate on, once instead of per metric.
+    # For flattened one-hot (LabelPartGroup) data this means reshaping back to
+    # (num_classes, *spatial_shape), extracting this instance and cropping; for normal
+    # data the already-cropped instance masks are used directly.
     needs_spatial = any(
         metric.requires_spatial and is_flattened_onehot for metric in eval_metrics
     )
-    ref_spatial = pred_spatial = None
     if needs_spatial:
-        # Reshape full arrays back to (num_classes, *spatial_shape) only once
+        assert n_ref_labels is not None and processing_pair_orig_shape is not None
         ref_spatial = _get_orig_onehotcc_structure(
             reference_arr, n_ref_labels, processing_pair_orig_shape
         )
         pred_spatial = _get_orig_onehotcc_structure(
             prediction_arr, n_ref_labels, processing_pair_orig_shape
         )
+        ref_spatial_instance = ref_spatial == ref_idx
+        pred_spatial_instance = pred_spatial == ref_idx
+        spatial_crop = _get_paired_crop(pred_spatial_instance, ref_spatial_instance)
+        spatial_ref = ref_spatial_instance[spatial_crop]
+        spatial_pred = pred_spatial_instance[spatial_crop]
+        spatial_voxelspacing = _extended_voxelspacing(voxelspacing, spatial_ref.ndim)
+    else:
+        spatial_ref, spatial_pred = ref_arr, pred_arr
+        spatial_voxelspacing = voxelspacing
+
+    # ASSD/HD/HD95/NSD are all reductions of the same directional surface-distance
+    # pair, so compute it once for this instance and reduce, rather than recomputing
+    # the distance transforms inside every surface metric.
+    surface_pair = None
+    if any(m.name in SURFACE_DISTANCE_METRIC_NAMES for m in eval_metrics):
+        surface_pair = _surface_distance_pair(
+            spatial_ref, spatial_pred, voxelspacing=spatial_voxelspacing
+        )
 
     for metric in eval_metrics:
-        if metric.requires_spatial and is_flattened_onehot:
-            # For spatial metrics on flattened one-hot data, use cached spatial structure
-
-            # Extract the specific instance from the spatial structure
-            ref_spatial_instance = ref_spatial == ref_idx
-            pred_spatial_instance = pred_spatial == ref_idx
-
-            # Crop for performance (only on spatial dimensions)
-            crop = _get_paired_crop(pred_spatial_instance, ref_spatial_instance)
-            ref_spatial_cropped = ref_spatial_instance[crop]
-            pred_spatial_cropped = pred_spatial_instance[crop]
-
-            # Adjust voxelspacing to match spatial array dimensions if needed
-            if len(voxelspacing) < ref_spatial_cropped.ndim:
-                # After reshaping from flattened one-hot, arrays have shape (num_labels+1, *spatial_shape)
-                # The instance extraction preserves this shape as a boolean mask
-                # Spatial metrics require voxelspacing for ALL dimensions, so we prepend 1.0
-                # for the non-spatial label dimension(s)
-                extra_dims = ref_spatial_cropped.ndim - len(voxelspacing)
-                extended_voxelspacing = (1.0,) * extra_dims + tuple(voxelspacing)
-            elif len(voxelspacing) > ref_spatial_cropped.ndim:
-                raise ValueError(
-                    f"Voxelspacing has {len(voxelspacing)} dimensions but the spatial array "
-                    f"only has {ref_spatial_cropped.ndim} dimensions. Voxelspacing should match "
-                    f"the original spatial dimensions of the data."
-                )
-            else:
-                extended_voxelspacing = voxelspacing
-
+        if metric.name in SURFACE_DISTANCE_METRIC_NAMES:
+            assert surface_pair is not None
+            metric_value = _reduce_surface_metric(
+                metric.name,
+                surface_pair[0],
+                surface_pair[1],
+                voxelspacing=spatial_voxelspacing,
+            )
+        elif metric.requires_spatial and is_flattened_onehot:
+            # Spatial-but-not-surface metrics (e.g. center distance) on one-hot data.
             metric_value = metric(
-                ref_spatial_cropped,
-                pred_spatial_cropped,
-                voxelspacing=extended_voxelspacing,
+                spatial_ref, spatial_pred, voxelspacing=spatial_voxelspacing
             )
         else:
-            # For non-spatial metrics or normal arrays, use standard computation
+            # Non-spatial metrics, or any metric on normal (non-one-hot) arrays.
             metric_value = metric(ref_arr, pred_arr, voxelspacing=voxelspacing)
 
         result[metric] = metric_value

--- a/panoptica/metrics/_surface_distances.py
+++ b/panoptica/metrics/_surface_distances.py
@@ -1,0 +1,129 @@
+"""Shared surface-distance computation for the surface-based metric family.
+
+ASSD, Hausdorff distance (HD), HD95 and the Normalized Surface Dice (NSD) are all
+reductions of the *same* two directional surface-distance arrays between a reference
+and a prediction mask. Computed independently (as the per-metric functions do) the
+same Euclidean distance transforms are recomputed up to four times for one instance
+pair. :func:`_surface_distance_pair` computes them once; the ``_*_from_pair`` reducers
+turn that single result into each metric, so requesting several surface metrics for an
+instance costs two distance transforms instead of up to eight.
+
+The reducers intentionally mirror the standalone implementations in :mod:`.assd`,
+:mod:`.hausdorff_distance` and :mod:`.normalized_surface_dice` exactly (same border
+extraction, same distance transform, same arithmetic), so results are bit-identical.
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+
+import numpy as np
+from scipy.ndimage import _ni_support, binary_erosion, generate_binary_structure
+
+from panoptica.metrics.assd import _distance_transform_edt
+
+# Metrics that are pure reductions of the directional surface-distance pair.
+SURFACE_DISTANCE_METRIC_NAMES = frozenset({"ASSD", "HD", "HD95", "NSD"})
+
+
+def _surface_distance_pair(
+    reference: np.ndarray,
+    prediction: np.ndarray,
+    voxelspacing=None,
+    connectivity: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute both directional surface-distance arrays in a single pass each.
+
+    Args:
+        reference: Boolean (or label) reference mask.
+        prediction: Boolean (or label) prediction mask.
+        voxelspacing: Physical spacing per axis; ``None`` means isotropic unit spacing.
+        connectivity: Connectivity for the border-extracting structuring element.
+
+    Returns:
+        ``(sd_ref, sd_pred)`` where ``sd_ref`` holds, for every reference-surface voxel,
+        the distance to the nearest prediction-surface voxel, and ``sd_pred`` the
+        symmetric quantity. These equal ``__surface_distances(prediction, reference)``
+        and ``__surface_distances(reference, prediction)`` respectively.
+    """
+    prediction = np.atleast_1d(prediction.astype(bool))
+    reference = np.atleast_1d(reference.astype(bool))
+    if voxelspacing is not None:
+        voxelspacing = _ni_support._normalize_sequence(voxelspacing, prediction.ndim)
+        voxelspacing = np.asarray(voxelspacing, dtype=np.float64)
+        if not voxelspacing.flags.contiguous:
+            voxelspacing = voxelspacing.copy()
+
+    footprint = generate_binary_structure(prediction.ndim, connectivity)
+    prediction_border = prediction ^ binary_erosion(
+        prediction, structure=footprint, iterations=1
+    )
+    reference_border = reference ^ binary_erosion(
+        reference, structure=footprint, iterations=1
+    )
+
+    # scipy's EDT measures distance to the nearest background voxel, so each border is
+    # inverted before transforming (as in the original __surface_distances).
+    sd_ref = _distance_transform_edt(~prediction_border, sampling=voxelspacing)[
+        reference_border
+    ]
+    sd_pred = _distance_transform_edt(~reference_border, sampling=voxelspacing)[
+        prediction_border
+    ]
+    return sd_ref, sd_pred
+
+
+def _assd_from_pair(sd_ref: np.ndarray, sd_pred: np.ndarray) -> float:
+    """Average Symmetric Surface Distance: mean of the two mean surface distances."""
+    return float(np.mean((sd_ref.mean(), sd_pred.mean())))
+
+
+def _hd_from_pair(sd_ref: np.ndarray, sd_pred: np.ndarray) -> float:
+    """Hausdorff distance: the larger of the two directional maxima."""
+    return max(sd_ref.max(), sd_pred.max())
+
+
+def _hd95_from_pair(sd_ref: np.ndarray, sd_pred: np.ndarray) -> float:
+    """95th-percentile Hausdorff distance over the pooled surface distances."""
+    return np.percentile(np.hstack((sd_ref, sd_pred)), 95)
+
+
+def _nsd_from_pair(
+    sd_ref: np.ndarray,
+    sd_pred: np.ndarray,
+    voxelspacing=None,
+    threshold=None,
+) -> float:
+    """Normalized Surface Dice at ``threshold`` (default: min voxel spacing, else 0.5)."""
+    if threshold is None:
+        threshold = min(voxelspacing) if voxelspacing is not None else 0.5
+    if threshold == 0.5:
+        warnings.warn(
+            "The threshold is set to 0.5, which is the default value, which may not be appropriate for your data."
+        )
+    numel_a = len(sd_ref)
+    numel_b = len(sd_pred)
+    tp_a = np.sum(sd_ref <= threshold) / numel_a
+    tp_b = np.sum(sd_pred <= threshold) / numel_b
+    fp = np.sum(sd_ref > threshold) / numel_a
+    fn = np.sum(sd_pred > threshold) / numel_b
+    return (tp_a + tp_b) / (tp_a + tp_b + fp + fn + sys.float_info.min)
+
+
+def _reduce_surface_metric(
+    metric_name: str,
+    sd_ref: np.ndarray,
+    sd_pred: np.ndarray,
+    voxelspacing=None,
+) -> float:
+    """Dispatch a surface-distance metric by name onto the precomputed pair."""
+    if metric_name == "ASSD":
+        return _assd_from_pair(sd_ref, sd_pred)
+    if metric_name == "HD":
+        return _hd_from_pair(sd_ref, sd_pred)
+    if metric_name == "HD95":
+        return _hd95_from_pair(sd_ref, sd_pred)
+    if metric_name == "NSD":
+        return _nsd_from_pair(sd_ref, sd_pred, voxelspacing=voxelspacing)
+    raise ValueError(f"{metric_name} is not a surface-distance metric")

--- a/panoptica/metrics/assd.py
+++ b/panoptica/metrics/assd.py
@@ -1,3 +1,5 @@
+"""Average Symmetric Surface Distance and the shared surface-distance machinery."""
+
 import numpy as np
 from scipy.ndimage import _ni_support, binary_erosion, generate_binary_structure
 from scipy.ndimage._nd_image import euclidean_feature_transform

--- a/panoptica/metrics/center_distance.py
+++ b/panoptica/metrics/center_distance.py
@@ -1,3 +1,5 @@
+"""Center-of-mass distance metric (CEDI)."""
+
 import numpy as np
 from scipy.ndimage import center_of_mass
 

--- a/panoptica/metrics/cldice.py
+++ b/panoptica/metrics/cldice.py
@@ -1,3 +1,5 @@
+"""Centerline Dice (clDSC) via skeletonization."""
+
 import numpy as np
 from skimage.morphology import skeletonize
 
@@ -5,7 +7,7 @@ try:
     from skimage.morphology import skeletonize_3d
 except ImportError:
     # In newer skimage versions (0.23+), skeletonize handles both 2D and 3D
-    skeletonize_3d = None
+    skeletonize_3d = None  # type: ignore[assignment]
 
 
 def _get_skeleton(array: np.ndarray) -> np.ndarray:
@@ -39,7 +41,7 @@ def cl_score(volume: np.ndarray, skeleton: np.ndarray):
         skeleton (np.ndarray): skeleton
 
     Returns:
-        _type_: skeleton overlap
+        float: Skeleton overlap fraction.
     """
     return np.sum(volume * skeleton) / np.sum(skeleton)
 

--- a/panoptica/metrics/dice.py
+++ b/panoptica/metrics/dice.py
@@ -1,3 +1,5 @@
+"""Dice (volumetric Dice) coefficient."""
+
 import numpy as np
 
 

--- a/panoptica/metrics/hausdorff_distance.py
+++ b/panoptica/metrics/hausdorff_distance.py
@@ -1,5 +1,6 @@
+"""Hausdorff distance (HD) and 95th-percentile Hausdorff distance (HD95)."""
+
 import numpy as np
-from scipy.spatial import cKDTree
 from panoptica.metrics.assd import __surface_distances
 
 
@@ -16,12 +17,12 @@ def _compute_instance_hausdorff_distance(
     """Computes the hausdroff distance between two instances.
 
     Args:
-        ref_labels (np.ndarray): _description_
-        pred_labels (np.ndarray): _description_
-        ref_instance_idx (int | None, optional): _description_. Defaults to None.
-        pred_instance_idx (int | None, optional): _description_. Defaults to None.
-        voxelspacing (_type_, optional): _description_. Defaults to None.
-        connectivity (int, optional): _description_. Defaults to 1.
+        ref_labels (np.ndarray): Reference label array.
+        pred_labels (np.ndarray): Prediction label array.
+        ref_instance_idx (int | None, optional): Reference instance label to isolate before computing. Defaults to None.
+        pred_instance_idx (int | None, optional): Prediction instance label to isolate before computing. Defaults to None.
+        voxelspacing (tuple[float, ...] | None, optional): Physical spacing per axis; None means isotropic unit spacing. Defaults to None.
+        connectivity (int, optional): Connectivity of the border-extracting structuring element. Defaults to 1.
 
     Returns:
         float: Hausdorff Distance
@@ -54,10 +55,10 @@ def _compute_hausdorff_distance(
     """Computes the hausdroff distance between two instances.
 
     Args:
-        ref_labels (np.ndarray): _description_
-        pred_labels (np.ndarray): _description_
-        voxelspacing (_type_, optional): _description_. Defaults to None.
-        connectivity (int, optional): _description_. Defaults to 1.
+        ref_labels (np.ndarray): Reference label array.
+        pred_labels (np.ndarray): Prediction label array.
+        voxelspacing (tuple[float, ...] | None, optional): Physical spacing per axis; None means isotropic unit spacing. Defaults to None.
+        connectivity (int, optional): Connectivity of the border-extracting structuring element. Defaults to 1.
 
     Returns:
         float: Hausdorff Distance
@@ -81,12 +82,12 @@ def _compute_instance_hausdorff_distance95(
     """Computes the hausdroff distance between two instances.
 
     Args:
-        ref_labels (np.ndarray): _description_
-        pred_labels (np.ndarray): _description_
-        ref_instance_idx (int | None, optional): _description_. Defaults to None.
-        pred_instance_idx (int | None, optional): _description_. Defaults to None.
-        voxelspacing (_type_, optional): _description_. Defaults to None.
-        connectivity (int, optional): _description_. Defaults to 1.
+        ref_labels (np.ndarray): Reference label array.
+        pred_labels (np.ndarray): Prediction label array.
+        ref_instance_idx (int | None, optional): Reference instance label to isolate before computing. Defaults to None.
+        pred_instance_idx (int | None, optional): Prediction instance label to isolate before computing. Defaults to None.
+        voxelspacing (tuple[float, ...] | None, optional): Physical spacing per axis; None means isotropic unit spacing. Defaults to None.
+        connectivity (int, optional): Connectivity of the border-extracting structuring element. Defaults to 1.
 
     Returns:
         float: Hausdorff Distance
@@ -119,10 +120,10 @@ def _compute_hausdorff_distance95(
     """Computes the hausdroff distance 95 between two instances.
 
     Args:
-        ref_labels (np.ndarray): _description_
-        pred_labels (np.ndarray): _description_
-        voxelspacing (_type_, optional): _description_. Defaults to None.
-        connectivity (int, optional): _description_. Defaults to 1.
+        ref_labels (np.ndarray): Reference label array.
+        pred_labels (np.ndarray): Prediction label array.
+        voxelspacing (tuple[float, ...] | None, optional): Physical spacing per axis; None means isotropic unit spacing. Defaults to None.
+        connectivity (int, optional): Connectivity of the border-extracting structuring element. Defaults to 1.
 
     Returns:
         float: Hausdorff Distance

--- a/panoptica/metrics/hausdorff_distance.py
+++ b/panoptica/metrics/hausdorff_distance.py
@@ -79,7 +79,7 @@ def _compute_instance_hausdorff_distance95(
     *args,
     **kwargs,
 ):
-    """Computes the hausdroff distance between two instances.
+    """Computes the hausdorff distance between two instances.
 
     Args:
         ref_labels (np.ndarray): Reference label array.

--- a/panoptica/metrics/hausdorff_distance.py
+++ b/panoptica/metrics/hausdorff_distance.py
@@ -117,7 +117,7 @@ def _compute_hausdorff_distance95(
     *args,
     **kwargs,
 ) -> float:
-    """Computes the hausdroff distance 95 between two instances.
+    """Computes the hausdorff distance 95 between two instances.
 
     Args:
         ref_labels (np.ndarray): Reference label array.

--- a/panoptica/metrics/hausdorff_distance.py
+++ b/panoptica/metrics/hausdorff_distance.py
@@ -14,7 +14,7 @@ def _compute_instance_hausdorff_distance(
     *args,
     **kwargs,
 ):
-    """Computes the hausdroff distance between two instances.
+    """Computes the hausdorff distance between two instances.
 
     Args:
         ref_labels (np.ndarray): Reference label array.

--- a/panoptica/metrics/iou.py
+++ b/panoptica/metrics/iou.py
@@ -1,3 +1,5 @@
+"""Intersection-over-Union (Jaccard) metric."""
+
 import numpy as np
 
 

--- a/panoptica/metrics/metrics.py
+++ b/panoptica/metrics/metrics.py
@@ -1,22 +1,33 @@
+"""Metric registry: the Metric enum and its supporting value and edge-case types."""
+
+from collections.abc import Callable
 from dataclasses import dataclass
-from enum import EnumMeta
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from panoptica.metrics import (
+# Import directly from the metric submodules (not the panoptica.metrics package) to
+# avoid a circular import: panoptica.metrics.__init__ imports this module, so importing
+# back from the package here is ordering-sensitive and breaks under import sorting.
+from panoptica.metrics.assd import (
     _compute_instance_average_symmetric_surface_distance,
-    _compute_centerline_dice,
-    _compute_instance_volumetric_dice,
-    _compute_instance_iou,
-    _compute_instance_relative_volume_difference,
-    _compute_instance_relative_volume_error,
-    _compute_instance_center_distance,
+)
+from panoptica.metrics.center_distance import _compute_instance_center_distance
+from panoptica.metrics.cldice import _compute_centerline_dice
+from panoptica.metrics.dice import _compute_instance_volumetric_dice
+from panoptica.metrics.hausdorff_distance import (
     _compute_instance_hausdorff_distance,
     _compute_instance_hausdorff_distance95,
-    # _compute_instance_segmentation_tendency,
+)
+from panoptica.metrics.iou import _compute_instance_iou
+from panoptica.metrics.normalized_surface_dice import (
     _compute_instance_normalized_surface_dice,
-    _compute_normalized_surface_dice,
+)
+from panoptica.metrics.relative_absolute_volume_error import (
+    _compute_instance_relative_volume_error,
+)
+from panoptica.metrics.relative_volume_difference import (
+    _compute_instance_relative_volume_difference,
 )
 from panoptica.utils.constants import _Enum_Compare, auto
 
@@ -78,12 +89,13 @@ class _Metric:
             int | float: The computed metric value.
         """
         if ref_instance_idx is not None and pred_instance_idx is not None:
-            reference_arr = reference_arr.copy() == ref_instance_idx
+            # ``==`` and ``np.isin`` already allocate fresh arrays and never mutate
+            # their inputs, so an explicit ``.copy()`` first would only double the
+            # memory traffic on this hot path (runs per metric and per match pair).
+            reference_arr = reference_arr == ref_instance_idx
             if isinstance(pred_instance_idx, int):
                 pred_instance_idx = [pred_instance_idx]
-            prediction_arr = np.isin(
-                prediction_arr.copy(), pred_instance_idx
-            )  # type: ignore
+            prediction_arr = np.isin(prediction_arr, pred_instance_idx)
         return self._metric_function(reference_arr, prediction_arr, *args, **kwargs)
 
     def __eq__(self, __value: object) -> bool:
@@ -144,22 +156,9 @@ class _Metric:
         )
 
 
-class DirectValueMeta(EnumMeta):
-    "Metaclass that allows for directly getting an enum attribute"
-
-    def __getattribute__(cls, name) -> _Metric:
-        value = super().__getattribute__(name)
-        if isinstance(value, cls):
-            value = value.value
-        return value
-
-
 class Metric(_Enum_Compare):
     """Enum containing important metrics that must be calculated in the evaluator, can be set for thresholding in matching and evaluation
-    Never call the .value member here, use the properties directly
-
-    Returns:
-        _type_: _description_
+    Never call the .value member here, use the properties directly.
     """
 
     DSC = _Metric("DSC", "Dice", False, False, _compute_instance_volumetric_dice)
@@ -243,10 +242,10 @@ class Metric(_Enum_Compare):
             int | float: The metric value
         """
         return self.value(
-            reference_arr=reference_arr,
-            prediction_arr=prediction_arr,
-            ref_instance_idx=ref_instance_idx,
-            pred_instance_idx=pred_instance_idx,
+            reference_arr,
+            prediction_arr,
+            ref_instance_idx,
+            pred_instance_idx,
             *args,
             **kwargs,
         )
@@ -299,11 +298,7 @@ class Metric(_Enum_Compare):
 
 
 class MetricMode(_Enum_Compare):
-    """Different modalities from Metrics
-
-    Args:
-        _Enum_Compare (_type_): _description_
-    """
+    """Different modalities from Metrics"""
 
     ALL = auto()
     AVG = auto()
@@ -314,11 +309,7 @@ class MetricMode(_Enum_Compare):
 
 
 class MetricType(_Enum_Compare):
-    """Different type of metrics
-
-    Args:
-        _Enum_Compare (_type_): _description_
-    """
+    """Different type of metrics"""
 
     NO_PRINT = auto()
     MATCHING = auto()
@@ -370,14 +361,13 @@ class Evaluation_Metric:
         """If called, needs to return its way, raise error or calculate it
 
         Args:
-            result_obj (PanopticaResult): _description_
+            result_obj (PanopticaResult): The result object the metric is computed from.
 
         Raises:
-            MetricCouldNotBeComputedException: _description_
-            self._error_obj: _description_
+            MetricCouldNotBeComputedException: If the metric or one of its dependencies could not be computed.
 
         Returns:
-            Any: _description_
+            Any: The computed metric value.
         """
         # ERROR
         if self._error:
@@ -443,7 +433,9 @@ class Evaluation_List_Metric:
             self.MAX: None | float = edge_case_result
         else:
             self.AVG = (
-                None if self.ALL is None or len(self.ALL) == 0 else np.average(self.ALL)
+                None
+                if self.ALL is None or len(self.ALL) == 0
+                else float(np.average(self.ALL))
             )
             self.SUM = (
                 None if self.ALL is None or len(self.ALL) == 0 else np.sum(self.ALL)
@@ -458,7 +450,9 @@ class Evaluation_List_Metric:
         self.STD = (
             None
             if self.ALL is None
-            else empty_list_std if len(self.ALL) == 0 else np.std(self.ALL)
+            else empty_list_std
+            if len(self.ALL) == 0
+            else np.std(self.ALL)
         )
 
     def __getitem__(self, mode: MetricMode | str):

--- a/panoptica/metrics/normalized_surface_dice.py
+++ b/panoptica/metrics/normalized_surface_dice.py
@@ -1,4 +1,7 @@
-import sys, warnings
+"""Normalized Surface Dice (NSD)."""
+
+import sys
+import warnings
 import numpy as np
 from panoptica.metrics.assd import __surface_distances
 
@@ -23,7 +26,7 @@ def _compute_normalized_surface_dice(
     Args:
         reference (np.ndarray): The reference mask
         prediction (np.ndarray): The prediction mask
-        voxelspacing (_type_, optional): The voxel spacing. Defaults to None.
+        voxelspacing (tuple[float, ...] | None, optional): The voxel spacing per axis. Defaults to None.
         connectivity (int, optional): The connectivity. Defaults to 1.
         threshold (float): The threshold for the surface distance in real world coordinates. If None, the minimum voxel spacing is used. If voxelspacing is None, the threshold is set to 0.5.
 
@@ -74,7 +77,7 @@ def _compute_instance_normalized_surface_dice(
         prediction (np.ndarray): The prediction mask
         ref_instance_idx (int | None, optional): The reference instance index. Defaults to None.
         pred_instance_idx (int | None, optional): The prediction instance index. Defaults to None.
-        voxelspacing (_type_, optional): The voxel spacing. Defaults to None.
+        voxelspacing (tuple[float, ...] | None, optional): The voxel spacing per axis. Defaults to None.
         connectivity (int, optional): The connectivity. Defaults to 1.
         threshold (float): The threshold for the surface distance in real world coordinates. If None, the minimum voxel spacing is used. If voxelspacing is None, the threshold is set to 0.5.
 

--- a/panoptica/metrics/relative_absolute_volume_error.py
+++ b/panoptica/metrics/relative_absolute_volume_error.py
@@ -1,3 +1,5 @@
+"""Relative Absolute Volume Error (RVAE)."""
+
 import numpy as np
 
 

--- a/panoptica/metrics/relative_volume_difference.py
+++ b/panoptica/metrics/relative_volume_difference.py
@@ -1,3 +1,5 @@
+"""Relative Volume Difference (RVD)."""
+
 import numpy as np
 
 

--- a/unit_tests/test_functionals_matching.py
+++ b/unit_tests/test_functionals_matching.py
@@ -1,0 +1,80 @@
+# Call 'python -m unittest' on this folder
+# coverage run -m unittest
+import os
+import unittest
+
+import numpy as np
+from scipy.ndimage import label as cc_label
+
+from panoptica.metrics import Metric
+from panoptica._functionals import (
+    _calc_overlapping_labels,
+    _calc_matching_metric_of_overlapping_labels,
+)
+
+
+def _brute_force_pairs(prediction_arr, reference_arr, ref_labels, metric):
+    """Reference implementation: evaluate the metric per overlapping pair."""
+    overlapping_labels = _calc_overlapping_labels(
+        prediction_arr=prediction_arr,
+        reference_arr=reference_arr,
+        ref_labels=ref_labels,
+    )
+    pairs = [
+        (metric.value(reference_arr, prediction_arr, r, p), (r, p))
+        for r, p in overlapping_labels
+    ]
+    return sorted(pairs, key=lambda x: x[0], reverse=not metric.decreasing)
+
+
+def _make_overlapping_case(seed, shape):
+    """Reference and prediction instance maps with independent label numbering."""
+    rng = np.random.default_rng(seed)
+    base = np.zeros(shape, dtype=np.int32)
+    for _ in range(60):
+        center = tuple(int(rng.integers(3, s - 3)) for s in shape)
+        sl = tuple(
+            slice(c - int(rng.integers(2, 5)), c + int(rng.integers(2, 5)))
+            for c in center
+        )
+        base[sl] = 1
+    reference_arr, _ = cc_label(base)
+
+    perturbed = base.copy() > 0
+    for ax in range(perturbed.ndim):
+        perturbed = np.roll(perturbed, int(rng.integers(-2, 3)), axis=ax)
+    perturbed = perturbed ^ (rng.random(perturbed.shape) < 0.02)
+    prediction_arr, _ = cc_label(perturbed)
+    return reference_arr.astype(np.int32), prediction_arr.astype(np.int32)
+
+
+class Test_VectorizedMatching(unittest.TestCase):
+    """The vectorized IoU/Dice matching must match the per-pair reference exactly."""
+
+    def setUp(self) -> None:
+        os.environ["PANOPTICA_CITATION_REMINDER"] = "False"
+        return super().setUp()
+
+    def test_iou_and_dice_match_bruteforce(self):
+        for seed in range(6):
+            for shape in [(80, 80), (40, 40, 24)]:
+                reference_arr, prediction_arr = _make_overlapping_case(seed, shape)
+                ref_labels = tuple(int(x) for x in np.unique(reference_arr) if x > 0)
+                if not ref_labels:
+                    continue
+                for metric in (Metric.IOU, Metric.DSC):
+                    fast = _calc_matching_metric_of_overlapping_labels(
+                        prediction_arr, reference_arr, ref_labels, metric
+                    )
+                    brute = _brute_force_pairs(
+                        prediction_arr, reference_arr, ref_labels, metric
+                    )
+                    self.assertEqual(len(fast), len(brute))
+                    for (s_fast, pair_fast), (s_brute, pair_brute) in zip(fast, brute):
+                        self.assertEqual(pair_fast, pair_brute)
+                        # bit-identical scores (same integer counts, same division)
+                        self.assertEqual(s_fast, s_brute)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/test_voronoi_regions.py
+++ b/unit_tests/test_voronoi_regions.py
@@ -5,8 +5,29 @@
 import os
 import unittest
 import numpy as np
+from scipy.ndimage import distance_transform_edt
 from panoptica.utils.processing_pair import UnmatchedInstancePair
 from panoptica._functionals import _get_voronoi_regions
+
+
+def _min_region_distance(arr: np.ndarray, n: int) -> np.ndarray:
+    """Per-voxel distance to the nearest labelled region (min over all regions)."""
+    per_region = np.stack(
+        [distance_transform_edt(arr != label) for label in range(1, n + 1)]
+    )
+    return per_region.min(axis=0)
+
+
+def _label_distance(arr: np.ndarray, region_map: np.ndarray, n: int) -> np.ndarray:
+    """Distance from each voxel to the region it was assigned to in ``region_map``."""
+    per_region = {
+        label: distance_transform_edt(arr != label) for label in range(1, n + 1)
+    }
+    out = np.zeros(arr.shape, dtype=float)
+    for label in range(1, n + 1):
+        sel = region_map == label
+        out[sel] = per_region[label][sel]
+    return out
 
 
 def create_test_data():
@@ -55,3 +76,56 @@ class Test_RegionMatching(unittest.TestCase):
         print(f"Matching successful!")
 
         self.assertTrue(True)
+
+    def test_voronoi_assigns_each_voxel_to_nearest_region(self):
+        """Every voxel must be assigned to a globally-nearest reference region.
+
+        This is the correctness contract of the single-pass implementation: interior
+        voxels keep their own label, and every voxel's assigned region is at the
+        minimal achievable distance (assignments may differ from a naive per-region
+        loop only at exactly-equidistant ties, which are arbitrary).
+        """
+        cases = [self._fixture_case()]
+        for seed in range(4):
+            cases.append(self._random_case(seed, (40, 40)))
+            cases.append(self._random_case(seed, (24, 24, 16)))
+
+        for arr, n in cases:
+            region_map, num = _get_voronoi_regions(arr, n)
+            self.assertEqual(num, n)
+            self.assertEqual(region_map.shape, arr.shape)
+
+            # 1. Interior voxels of every instance keep their own label.
+            interior = arr != 0
+            self.assertTrue(np.array_equal(region_map[interior], arr[interior]))
+
+            # 2. Every voxel is assigned to a region at the globally-minimal distance.
+            np.testing.assert_allclose(
+                _label_distance(arr, region_map, n),
+                _min_region_distance(arr, n),
+            )
+
+            # 3. Only valid region labels are emitted.
+            self.assertTrue(set(np.unique(region_map)).issubset(set(range(1, n + 1))))
+
+    @staticmethod
+    def _fixture_case():
+        gt = np.zeros((30, 30, 12), dtype=np.int32)
+        gt[5:10, 5:10, 3:9] = 1
+        gt[20:25, 20:25, 3:9] = 2
+        return gt, 2
+
+    @staticmethod
+    def _random_case(seed, shape):
+        rng = np.random.default_rng(seed)
+        arr = np.zeros(shape, dtype=np.int32)
+        n = 0
+        for _ in range(40):
+            if n >= 6:
+                break
+            center = tuple(int(rng.integers(2, s - 2)) for s in shape)
+            if arr[center] != 0:
+                continue
+            n += 1
+            arr[center] = n
+        return arr, n


### PR DESCRIPTION
---
**Stacked PRs** (review / merge bottom-up):

1. #269 Fix AUTC integration on NumPy < 2.0 ✅ merged
2. #273 Speed up matching, surface metrics, Voronoi, and per-instance evaluation ← **this PR**
3. #270 Add a logger and refactor the I/O and pipeline modules
4. #271 Finish the refactor: remaining cleanup, type hints, and docstrings
5. #272 Add dev tooling: ruff, mypy, pre-commit, CI gate, and benchmark
---

Behavior-preserving performance work, each covered by regression tests:

- Vectorize IoU/Dice matching (`np.unique`+`bincount` instead of a per-pair full-array metric eval).
- Share the two directional surface-distance arrays across ASSD/HD/HD95/NSD (up to 8 distance transforms → 2).
- Single-pass feature-transform Voronoi regions (~15–28×).
- Crop each instance to its bounding box via `scipy.ndimage.find_objects` (~4–6× on many-instance volumes).
- Drop a redundant array `.copy()`; remove the dead commented-out `Pool` block.